### PR TITLE
chore: readme update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ The NMM is a 5/7 multisig for passing a Noble Multisig proposal to fulfill the t
 - Chorus One: Switzerland
 - Binary Holdings: Switzerland 
 - Cosmostation: Korea  
-- EverStake: Ukraine/ Austria 
+- Luganodes: Switzerland 
 
 Stakeholders on the NMM will be able to be rotated in and out of the mulitisg over time. 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the list of stakeholders for the NMM multisig in the documentation, replacing "EverStake" with "Luganodes" and updating the location to Switzerland.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->