### PR TITLE
feat: add manual clearing for forwarding accounts

### DIFF
--- a/proto/noble/forwarding/v1/tx.proto
+++ b/proto/noble/forwarding/v1/tx.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/noble-assets/noble/v5/x/forwarding/types";
 
 service Msg {
   rpc RegisterAccount(noble.forwarding.v1.MsgRegisterAccount) returns (noble.forwarding.v1.MsgRegisterAccountResponse);
+  rpc ClearAccount(noble.forwarding.v1.MsgClearAccount) returns (noble.forwarding.v1.MsgClearAccountResponse);
 }
 
 //
@@ -19,3 +20,10 @@ message MsgRegisterAccount {
 message MsgRegisterAccountResponse {
   string address = 1;
 }
+
+message MsgClearAccount {
+  string signer = 1;
+  string address = 2;
+}
+
+message MsgClearAccountResponse {}

--- a/x/forwarding/client/cli/tx.go
+++ b/x/forwarding/client/cli/tx.go
@@ -15,6 +15,7 @@ func GetTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(TxRegisterAccount())
+	cmd.AddCommand(TxClearAccount())
 
 	return cmd
 }
@@ -33,6 +34,30 @@ func TxRegisterAccount() *cobra.Command {
 				Signer:    clientCtx.GetFromAddress().String(),
 				Recipient: args[1],
 				Channel:   args[0],
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func TxClearAccount() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "clear-account [address]",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := &types.MsgClearAccount{
+				Signer:  clientCtx.GetFromAddress().String(),
+				Address: args[0],
 			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)

--- a/x/forwarding/types/codec.go
+++ b/x/forwarding/types/codec.go
@@ -20,11 +20,13 @@ func init() {
 
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgRegisterAccount{}, "noble/forwarding/RegisterAccount", nil)
+	cdc.RegisterConcrete(&MsgClearAccount{}, "noble/forwarding/ClearAccount", nil)
 }
 
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*authtypes.AccountI)(nil), &ForwardingAccount{})
 
 	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgRegisterAccount{})
+	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgClearAccount{})
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }

--- a/x/forwarding/types/messages.go
+++ b/x/forwarding/types/messages.go
@@ -44,3 +44,43 @@ func (msg *MsgRegisterAccount) Route() string {
 func (msg *MsgRegisterAccount) Type() string {
 	return "noble/forwarding/RegisterAccount"
 }
+
+//
+
+var _ legacytx.LegacyMsg = &MsgClearAccount{}
+
+func (msg *MsgClearAccount) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(msg.Signer)
+	if err != nil {
+		return errors.New("invalid signer")
+	}
+
+	_, err = sdk.AccAddressFromBech32(msg.Address)
+	if err != nil {
+		return errors.New("invalid address")
+	}
+
+	return nil
+}
+
+func (msg *MsgClearAccount) GetSigners() []sdk.AccAddress {
+	signer, err := sdk.AccAddressFromBech32(msg.Signer)
+	if err != nil {
+		panic(err)
+	}
+
+	return []sdk.AccAddress{signer}
+}
+
+func (msg *MsgClearAccount) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgClearAccount) Route() string {
+	return ModuleName
+}
+
+func (msg *MsgClearAccount) Type() string {
+	return "noble/forwarding/ClearAccount"
+}

--- a/x/forwarding/types/tx.pb.go
+++ b/x/forwarding/types/tx.pb.go
@@ -131,32 +131,125 @@ func (m *MsgRegisterAccountResponse) GetAddress() string {
 	return ""
 }
 
+type MsgClearAccount struct {
+	Signer  string `protobuf:"bytes,1,opt,name=signer,proto3" json:"signer,omitempty"`
+	Address string `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
+}
+
+func (m *MsgClearAccount) Reset()         { *m = MsgClearAccount{} }
+func (m *MsgClearAccount) String() string { return proto.CompactTextString(m) }
+func (*MsgClearAccount) ProtoMessage()    {}
+func (*MsgClearAccount) Descriptor() ([]byte, []int) {
+	return fileDescriptor_e8a8b8337aa6ea1a, []int{2}
+}
+func (m *MsgClearAccount) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgClearAccount) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgClearAccount.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgClearAccount) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgClearAccount.Merge(m, src)
+}
+func (m *MsgClearAccount) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgClearAccount) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgClearAccount.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgClearAccount proto.InternalMessageInfo
+
+func (m *MsgClearAccount) GetSigner() string {
+	if m != nil {
+		return m.Signer
+	}
+	return ""
+}
+
+func (m *MsgClearAccount) GetAddress() string {
+	if m != nil {
+		return m.Address
+	}
+	return ""
+}
+
+type MsgClearAccountResponse struct {
+}
+
+func (m *MsgClearAccountResponse) Reset()         { *m = MsgClearAccountResponse{} }
+func (m *MsgClearAccountResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgClearAccountResponse) ProtoMessage()    {}
+func (*MsgClearAccountResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_e8a8b8337aa6ea1a, []int{3}
+}
+func (m *MsgClearAccountResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgClearAccountResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgClearAccountResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgClearAccountResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgClearAccountResponse.Merge(m, src)
+}
+func (m *MsgClearAccountResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgClearAccountResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgClearAccountResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgClearAccountResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgRegisterAccount)(nil), "noble.forwarding.v1.MsgRegisterAccount")
 	proto.RegisterType((*MsgRegisterAccountResponse)(nil), "noble.forwarding.v1.MsgRegisterAccountResponse")
+	proto.RegisterType((*MsgClearAccount)(nil), "noble.forwarding.v1.MsgClearAccount")
+	proto.RegisterType((*MsgClearAccountResponse)(nil), "noble.forwarding.v1.MsgClearAccountResponse")
 }
 
 func init() { proto.RegisterFile("noble/forwarding/v1/tx.proto", fileDescriptor_e8a8b8337aa6ea1a) }
 
 var fileDescriptor_e8a8b8337aa6ea1a = []byte{
-	// 260 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x90, 0xb1, 0x4e, 0xc3, 0x30,
-	0x10, 0x86, 0x63, 0x2a, 0x15, 0xd5, 0x0b, 0x92, 0x91, 0x50, 0x54, 0x55, 0x16, 0xea, 0x02, 0x0b,
-	0xb6, 0x4a, 0x05, 0x3b, 0xec, 0x59, 0x32, 0xb2, 0x25, 0xce, 0xe1, 0x5a, 0x14, 0x3b, 0xf2, 0xb9,
-	0xa1, 0xbc, 0x05, 0x8f, 0xc5, 0xd8, 0x91, 0x11, 0x25, 0x2f, 0x82, 0x30, 0x8d, 0x8a, 0x28, 0x43,
-	0xc7, 0xcf, 0x9f, 0xed, 0xff, 0xee, 0xa7, 0x13, 0xeb, 0xca, 0x25, 0xc8, 0x47, 0xe7, 0x5f, 0x0a,
-	0x5f, 0x19, 0xab, 0x65, 0x33, 0x93, 0x61, 0x2d, 0x6a, 0xef, 0x82, 0x63, 0xa7, 0xd1, 0x8a, 0x9d,
-	0x15, 0xcd, 0x6c, 0x5a, 0x51, 0x96, 0xa1, 0xce, 0x41, 0x1b, 0x0c, 0xe0, 0xef, 0x94, 0x72, 0x2b,
-	0x1b, 0xd8, 0x19, 0x1d, 0xa2, 0xd1, 0x16, 0x7c, 0x4a, 0xce, 0xc9, 0xe5, 0x28, 0xdf, 0x12, 0x9b,
-	0xd0, 0x91, 0x07, 0x65, 0x6a, 0x03, 0x36, 0xa4, 0x47, 0x51, 0xed, 0x0e, 0x58, 0x4a, 0x8f, 0xd5,
-	0xa2, 0xb0, 0x16, 0x96, 0xe9, 0x20, 0xba, 0x1e, 0xa7, 0xb7, 0x74, 0xbc, 0x9f, 0x92, 0x03, 0xd6,
-	0xce, 0x22, 0x7c, 0xbf, 0x2b, 0xaa, 0xca, 0x03, 0xe2, 0x36, 0xae, 0xc7, 0x6b, 0x4f, 0x07, 0x19,
-	0x6a, 0xf6, 0x44, 0x4f, 0xfe, 0x4e, 0x78, 0x21, 0xfe, 0xd9, 0x46, 0xec, 0x87, 0x8c, 0xe5, 0x81,
-	0x17, 0xfb, 0x69, 0xee, 0xb3, 0xf7, 0x96, 0x93, 0x4d, 0xcb, 0xc9, 0x67, 0xcb, 0xc9, 0x5b, 0xc7,
-	0x93, 0x4d, 0xc7, 0x93, 0x8f, 0x8e, 0x27, 0x0f, 0x73, 0x6d, 0xc2, 0x62, 0x55, 0x0a, 0xe5, 0x9e,
-	0x65, 0xfc, 0xf4, 0xaa, 0x40, 0x84, 0x80, 0x3f, 0x20, 0x9b, 0x1b, 0xb9, 0xfe, 0xdd, 0x7d, 0x78,
-	0xad, 0x01, 0xcb, 0x61, 0x2c, 0x7f, 0xfe, 0x15, 0x00, 0x00, 0xff, 0xff, 0x92, 0x6e, 0x57, 0xa2,
-	0x9c, 0x01, 0x00, 0x00,
+	// 306 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x52, 0x4f, 0x4f, 0x3a, 0x31,
+	0x14, 0xa4, 0x90, 0xf0, 0x0b, 0xcd, 0x2f, 0x21, 0xa9, 0x89, 0xae, 0x84, 0x34, 0x86, 0x98, 0xe8,
+	0x41, 0xdb, 0x20, 0xd1, 0xbb, 0x72, 0xde, 0x0b, 0x47, 0x6f, 0xfb, 0xe7, 0x59, 0x1a, 0xb1, 0xdd,
+	0xf4, 0x15, 0xc4, 0x6f, 0xe1, 0xc7, 0xf2, 0xc8, 0xc9, 0x78, 0x34, 0xf0, 0x45, 0x8c, 0x2b, 0x2b,
+	0x0b, 0x68, 0xe4, 0x38, 0x9d, 0xe9, 0xcc, 0x9b, 0x97, 0x47, 0xdb, 0xc6, 0xc6, 0x23, 0x90, 0x77,
+	0xd6, 0x3d, 0x46, 0x2e, 0xd5, 0x46, 0xc9, 0x49, 0x57, 0xfa, 0xa9, 0xc8, 0x9c, 0xf5, 0x96, 0xed,
+	0xe5, 0xac, 0x58, 0xb1, 0x62, 0xd2, 0xed, 0xa4, 0x94, 0x85, 0xa8, 0x06, 0xa0, 0x34, 0x7a, 0x70,
+	0xd7, 0x49, 0x62, 0xc7, 0xc6, 0xb3, 0x7d, 0x5a, 0x47, 0xad, 0x0c, 0xb8, 0x80, 0x1c, 0x91, 0xd3,
+	0xc6, 0x60, 0x89, 0x58, 0x9b, 0x36, 0x1c, 0x24, 0x3a, 0xd3, 0x60, 0x7c, 0x50, 0xcd, 0xa9, 0xd5,
+	0x03, 0x0b, 0xe8, 0xbf, 0x64, 0x18, 0x19, 0x03, 0xa3, 0xa0, 0x96, 0x73, 0x05, 0xec, 0x5c, 0xd1,
+	0xd6, 0x76, 0xca, 0x00, 0x30, 0xb3, 0x06, 0xe1, 0xf3, 0x5f, 0x94, 0xa6, 0x0e, 0x10, 0x97, 0x71,
+	0x05, 0xec, 0xf4, 0x69, 0x33, 0x44, 0xd5, 0x1f, 0x41, 0xf4, 0xe7, 0x68, 0x25, 0x93, 0xea, 0xba,
+	0xc9, 0x21, 0x3d, 0xd8, 0x30, 0x29, 0x92, 0x2f, 0x5e, 0x09, 0xad, 0x85, 0xa8, 0xd8, 0x3d, 0x6d,
+	0x6e, 0xae, 0xe0, 0x44, 0xfc, 0xb0, 0x2e, 0xb1, 0xdd, 0xa2, 0x25, 0x77, 0x14, 0x7e, 0xd7, 0x8d,
+	0xe9, 0xff, 0xb5, 0x46, 0xc7, 0xbf, 0x19, 0x94, 0x55, 0xad, 0xb3, 0x5d, 0x54, 0x45, 0xc6, 0x4d,
+	0xf8, 0x32, 0xe7, 0x64, 0x36, 0xe7, 0xe4, 0x7d, 0xce, 0xc9, 0xf3, 0x82, 0x57, 0x66, 0x0b, 0x5e,
+	0x79, 0x5b, 0xf0, 0xca, 0x6d, 0x4f, 0x69, 0x3f, 0x1c, 0xc7, 0x22, 0xb1, 0x0f, 0x32, 0x77, 0x3c,
+	0x8f, 0x10, 0xc1, 0xe3, 0x17, 0x90, 0x93, 0x4b, 0x39, 0x2d, 0x1f, 0x90, 0x7f, 0xca, 0x00, 0xe3,
+	0x7a, 0x7e, 0x41, 0xbd, 0x8f, 0x00, 0x00, 0x00, 0xff, 0xff, 0xd8, 0x36, 0xbb, 0x75, 0x61, 0x02,
+	0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -172,6 +265,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
 	RegisterAccount(ctx context.Context, in *MsgRegisterAccount, opts ...grpc.CallOption) (*MsgRegisterAccountResponse, error)
+	ClearAccount(ctx context.Context, in *MsgClearAccount, opts ...grpc.CallOption) (*MsgClearAccountResponse, error)
 }
 
 type msgClient struct {
@@ -191,9 +285,19 @@ func (c *msgClient) RegisterAccount(ctx context.Context, in *MsgRegisterAccount,
 	return out, nil
 }
 
+func (c *msgClient) ClearAccount(ctx context.Context, in *MsgClearAccount, opts ...grpc.CallOption) (*MsgClearAccountResponse, error) {
+	out := new(MsgClearAccountResponse)
+	err := c.cc.Invoke(ctx, "/noble.forwarding.v1.Msg/ClearAccount", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	RegisterAccount(context.Context, *MsgRegisterAccount) (*MsgRegisterAccountResponse, error)
+	ClearAccount(context.Context, *MsgClearAccount) (*MsgClearAccountResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -202,6 +306,9 @@ type UnimplementedMsgServer struct {
 
 func (*UnimplementedMsgServer) RegisterAccount(ctx context.Context, req *MsgRegisterAccount) (*MsgRegisterAccountResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RegisterAccount not implemented")
+}
+func (*UnimplementedMsgServer) ClearAccount(ctx context.Context, req *MsgClearAccount) (*MsgClearAccountResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ClearAccount not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -226,6 +333,24 @@ func _Msg_RegisterAccount_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_ClearAccount_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgClearAccount)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).ClearAccount(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/noble.forwarding.v1.Msg/ClearAccount",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).ClearAccount(ctx, req.(*MsgClearAccount))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "noble.forwarding.v1.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -233,6 +358,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RegisterAccount",
 			Handler:    _Msg_RegisterAccount_Handler,
+		},
+		{
+			MethodName: "ClearAccount",
+			Handler:    _Msg_ClearAccount_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -313,6 +442,66 @@ func (m *MsgRegisterAccountResponse) MarshalToSizedBuffer(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgClearAccount) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgClearAccount) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgClearAccount) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Address) > 0 {
+		i -= len(m.Address)
+		copy(dAtA[i:], m.Address)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Address)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Signer) > 0 {
+		i -= len(m.Signer)
+		copy(dAtA[i:], m.Signer)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Signer)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgClearAccountResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgClearAccountResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgClearAccountResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -355,6 +544,32 @@ func (m *MsgRegisterAccountResponse) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovTx(uint64(l))
 	}
+	return n
+}
+
+func (m *MsgClearAccount) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Signer)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.Address)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgClearAccountResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
 	return n
 }
 
@@ -571,6 +786,170 @@ func (m *MsgRegisterAccountResponse) Unmarshal(dAtA []byte) error {
 			}
 			m.Address = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgClearAccount) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgClearAccount: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgClearAccount: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Signer", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Signer = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Address", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Address = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgClearAccountResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgClearAccountResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgClearAccountResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
 		default:
 			iNdEx = preIndex
 			skippy, err := skipTx(dAtA[iNdEx:])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new feature to clear an account through a CLI command or RPC method.
- **Enhancements**
	- Expanded existing functionalities to support the new `ClearAccount` feature, including adjustments in function signatures and message type registration.
- **Tests**
	- Enhanced test suite to accommodate new changes related to account clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->