### PR TITLE
fix: correctly check account existence

### DIFF
--- a/x/forwarding/keeper/msg_server.go
+++ b/x/forwarding/keeper/msg_server.go
@@ -24,7 +24,7 @@ func (k *Keeper) RegisterAccount(goCtx context.Context, msg *types.MsgRegisterAc
 	if k.authKeeper.HasAccount(ctx, address) {
 		rawAccount := k.authKeeper.GetAccount(ctx, address)
 		if rawAccount.GetPubKey() != nil || rawAccount.GetSequence() != 0 {
-			return nil, errors.New("attempting to register an existing user account")
+			return nil, fmt.Errorf("attempting to register an existing user account with address: %s", address.String())
 		}
 
 		switch account := rawAccount.(type) {
@@ -41,7 +41,7 @@ func (k *Keeper) RegisterAccount(goCtx context.Context, msg *types.MsgRegisterAc
 		case *types.ForwardingAccount:
 			return nil, errors.New("account has already been registered")
 		default:
-			break
+			return nil, fmt.Errorf("unsupported account type: %T", rawAccount)
 		}
 
 		if !k.bankKeeper.GetAllBalances(ctx, address).IsZero() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved account registration to check for existing accounts with non-nil public keys or non-zero sequences before registration. An error is now returned if an existing account is found with these attributes. Adjusted handling of account types to set up a `ForwardingAccount` based on the existing account type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->