### PR TITLE
chore: switch to tagged cosmos sdk fork

### DIFF
--- a/.changelog/unreleased/dependencies/385-cosmos-sdk.md
+++ b/.changelog/unreleased/dependencies/385-cosmos-sdk.md
@@ -1,0 +1,1 @@
+- Switch to Noble's Cosmos SDK fork ([`v0.45.16-send-restrictions`](https://github.com/noble-assets/cosmos-sdk/releases/tag/v0.45.16-send-restrictions)) that supports send restrictions. ([#385](https://github.com/noble-assets/noble/pull/385))

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ replace (
 	github.com/ChainSafe/go-schnorrkel => github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d
 
 	// use send restriction compatible cosmos/cosmos-sdk
-	github.com/cosmos/cosmos-sdk => github.com/noble-assets/cosmos-sdk v0.45.17-0.20240626105200-928be03f1633
+	github.com/cosmos/cosmos-sdk => github.com/noble-assets/cosmos-sdk v0.45.16-send-restrictions
 
 	// use macos sonoma compatible cosmos/ledger-cosmos-go
 	github.com/cosmos/ledger-cosmos-go => github.com/cosmos/ledger-cosmos-go v0.12.4

--- a/go.sum
+++ b/go.sum
@@ -963,8 +963,8 @@ github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
 github.com/noble-assets/aura v1.0.0-rc.0 h1:ngEFxynKz5hMmIt5HY59179d9KKzdIjZAkTKbrRlsZs=
 github.com/noble-assets/aura v1.0.0-rc.0/go.mod h1:IpxcXBQLqnodYnHPCPx2C2OhpfShfvvSL726u6WvBbk=
-github.com/noble-assets/cosmos-sdk v0.45.17-0.20240626105200-928be03f1633 h1:ogvlGIWP3oTRqDSRV4V+QJAiQD0Sk+7iHMrtlZmgCno=
-github.com/noble-assets/cosmos-sdk v0.45.17-0.20240626105200-928be03f1633/go.mod h1:bScuNwWAP0TZJpUf+SHXRU3xGoUPp+X9nAzfeIXts40=
+github.com/noble-assets/cosmos-sdk v0.45.16-send-restrictions h1:oQwbCoejkXp2/ozQSwc//A6UW9wJl71YgP7o04MsYq0=
+github.com/noble-assets/cosmos-sdk v0.45.16-send-restrictions/go.mod h1:bScuNwWAP0TZJpUf+SHXRU3xGoUPp+X9nAzfeIXts40=
 github.com/noble-assets/forwarding v1.1.0 h1:2TXBs2Y9vWqgHyDKtdcHht6i7OT+pLaVHE3bPvfpmJY=
 github.com/noble-assets/forwarding v1.1.0/go.mod h1:o64ZfzCHteRDhOlkpi7GeKAcjlcbWUihC7Y34Er2/3U=
 github.com/nunnatsa/ginkgolinter v0.14.0 h1:XQPNmw+kZz5cC/HbFK3mQutpjzAQv1dHregRA+4CGGg=


### PR DESCRIPTION
Now that [Halborn](https://www.halborn.com) has completed their audit of our Cosmos SDK fork, we have cut a tag to be included in the v5 release.