### PR TITLE
fix: move crisis module to be the last item in the initgenesis and endblockers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -621,7 +621,6 @@ func New(
 		stakingtypes.ModuleName,
 		authtypes.ModuleName,
 		banktypes.ModuleName,
-		crisistypes.ModuleName,
 		ibctransfertypes.ModuleName,
 		ibchost.ModuleName,
 		icatypes.ModuleName,
@@ -639,10 +638,10 @@ func New(
 		auratypes.ModuleName,
 		halotypes.ModuleName,
 		florintypes.ModuleName,
+		crisistypes.ModuleName,
 	)
 
 	app.mm.SetOrderEndBlockers(
-		crisistypes.ModuleName,
 		stakingtypes.ModuleName,
 		ibctransfertypes.ModuleName,
 		ibchost.ModuleName,
@@ -669,6 +668,7 @@ func New(
 		auratypes.ModuleName,
 		halotypes.ModuleName,
 		florintypes.ModuleName,
+		crisistypes.ModuleName,
 	)
 
 	// NOTE: The genutils module must occur after staking so that pools are


### PR DESCRIPTION
As `x/crisis` needs to have access to the latest state to do anything (not that it does much, or even if it does, does it as expected), it needs to run after all the end blockers so it has all the relevant state to run invariants on.