### PR TITLE
chore: add restricted module check

### DIFF
--- a/e2e/conformance_test.go
+++ b/e2e/conformance_test.go
@@ -23,9 +23,6 @@ import (
 )
 
 func TestConformance(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
 	t.Parallel()
 
 	ctx := context.Background()

--- a/e2e/module_check_test.go
+++ b/e2e/module_check_test.go
@@ -1,0 +1,25 @@
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/noble-assets/noble/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestrictedModules(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	nw := e2e.NobleSpinUp(t, ctx, false)
+	noble := nw.Chain.GetNode()
+
+	restrictedModules := []string{"circuit", "gov", "group"}
+
+	for _, module := range restrictedModules {
+		require.False(t, noble.HasCommand(ctx, "query", module), fmt.Sprintf("%s is a restricted module", module))
+	}
+}

--- a/e2e/module_check_test.go
+++ b/e2e/module_check_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 NASD Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2e_test
 
 import (


### PR DESCRIPTION
This CI test ensures that certain Go modules are not included in Noble.