### PR TITLE
fix: correctly initialize module version map

### DIFF
--- a/app.go
+++ b/app.go
@@ -229,6 +229,13 @@ func NewApp(
 		return nil, err
 	}
 
+	// When initializing the upgrade keeper via dependency injection, the
+	// initial module version map is created using only the modules that are
+	// wired through dependency injection. As a result, any "legacy" modules
+	// (those that don't support dependency injection) are excluded. The line
+	// below updates the version map to ensure that all modules are included.
+	app.UpgradeKeeper.SetInitVersionMap(app.ModuleManager.GetVersionMap())
+
 	anteHandler, err := NewAnteHandler(HandlerOptions{
 		HandlerOptions: ante.HandlerOptions{
 			AccountKeeper:   app.AccountKeeper,


### PR DESCRIPTION
As discovered in #422, the initial module version map passed to the `x/upgrade` Keeper was missing legacy modules.

This PR addresses this by reseting the initial version map once all modules (including legacy) have been registered!