### PR TITLE
chore: bump halo to `v2.0.1`

### DIFF
--- a/.changelog/unreleased/dependencies/431-bump-halo.md
+++ b/.changelog/unreleased/dependencies/431-bump-halo.md
@@ -1,0 +1,1 @@
+- Update `x/halo` to latest non-consensus breaking patch. ([#431](https://github.com/noble-assets/noble/pull/431))

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/monerium/module-noble/v2 v2.0.0
 	github.com/noble-assets/authority v1.0.0
 	github.com/noble-assets/globalfee v1.0.0
-	github.com/noble-assets/halo/v2 v2.0.0
+	github.com/noble-assets/halo/v2 v2.0.1
 	github.com/noble-assets/noble/v8 v8.0.0-rc.3
 	github.com/ondoprotocol/usdy-noble/v2 v2.0.0
 	github.com/strangelove-ventures/interchaintest/v8 v8.8.0

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -1140,8 +1140,7 @@ github.com/noble-assets/authority v1.0.0 h1:AItgvW6OEn7CocTuda3YjHuOq/7jTTyr1COp
 github.com/noble-assets/authority v1.0.0/go.mod h1:AyCyM1iP73dHxBsulw0GpZNgPIQvSndWp30pK87nmog=
 github.com/noble-assets/globalfee v1.0.0 h1:NUNDXd5tdzB5A/O8Em/1g+GU92E4lojH3+3lOwkbO+Y=
 github.com/noble-assets/globalfee v1.0.0/go.mod h1:DmNoTJ2LqGP4KpJuz+IEKp/5uf/3hRu3GSNBGhNUZkA=
-github.com/noble-assets/halo/v2 v2.0.0 h1:iyeb5U7GqMeKi5s8f5dop9lRMOO4NC8wki1FiNIx0r0=
-github.com/noble-assets/halo/v2 v2.0.0/go.mod h1:DY4GCfZ/7S3IEjoJBCCh7HRTxirPBOLMVwkT0N6n3bA=
+github.com/noble-assets/halo/v2 v2.0.1 h1:nHAhTnq5dPJGelcLnKzMviXtk9x0DfMnRPv+CPoEvyA=
 github.com/noble-assets/noble/v8 v8.0.0-rc.3 h1:jqBu7JXLzf0+sPaJuCyYwwhoW220t9yGKBS/iAPDyzg=
 github.com/noble-assets/noble/v8 v8.0.0-rc.3/go.mod h1:+wamFXopAPF08yL8cub00Spv/WRhfud+YqEhIcMjCVw=
 github.com/nunnatsa/ginkgolinter v0.16.2 h1:8iLqHIZvN4fTLDC0Ke9tbSZVcyVHoBs0HIbnVSxfHJk=

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -1141,6 +1141,7 @@ github.com/noble-assets/authority v1.0.0/go.mod h1:AyCyM1iP73dHxBsulw0GpZNgPIQvS
 github.com/noble-assets/globalfee v1.0.0 h1:NUNDXd5tdzB5A/O8Em/1g+GU92E4lojH3+3lOwkbO+Y=
 github.com/noble-assets/globalfee v1.0.0/go.mod h1:DmNoTJ2LqGP4KpJuz+IEKp/5uf/3hRu3GSNBGhNUZkA=
 github.com/noble-assets/halo/v2 v2.0.1 h1:nHAhTnq5dPJGelcLnKzMviXtk9x0DfMnRPv+CPoEvyA=
+github.com/noble-assets/halo/v2 v2.0.1/go.mod h1:DY4GCfZ/7S3IEjoJBCCh7HRTxirPBOLMVwkT0N6n3bA=
 github.com/noble-assets/noble/v8 v8.0.0-rc.3 h1:jqBu7JXLzf0+sPaJuCyYwwhoW220t9yGKBS/iAPDyzg=
 github.com/noble-assets/noble/v8 v8.0.0-rc.3/go.mod h1:+wamFXopAPF08yL8cub00Spv/WRhfud+YqEhIcMjCVw=
 github.com/nunnatsa/ginkgolinter v0.16.2 h1:8iLqHIZvN4fTLDC0Ke9tbSZVcyVHoBs0HIbnVSxfHJk=

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/noble-assets/authority v1.0.0
 	github.com/noble-assets/forwarding/v2 v2.0.0
 	github.com/noble-assets/globalfee v1.0.0
-	github.com/noble-assets/halo/v2 v2.0.0
+	github.com/noble-assets/halo/v2 v2.0.1
 	github.com/ondoprotocol/usdy-noble/v2 v2.0.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -1088,8 +1088,8 @@ github.com/noble-assets/forwarding/v2 v2.0.0 h1:6iBg51yEtIlSaDzW7o5g17SvP9o1rNOU
 github.com/noble-assets/forwarding/v2 v2.0.0/go.mod h1:bKHj4XWyTcJqr2/XliylHJ5Te4pTftCV0h4BpnLOmf0=
 github.com/noble-assets/globalfee v1.0.0 h1:NUNDXd5tdzB5A/O8Em/1g+GU92E4lojH3+3lOwkbO+Y=
 github.com/noble-assets/globalfee v1.0.0/go.mod h1:DmNoTJ2LqGP4KpJuz+IEKp/5uf/3hRu3GSNBGhNUZkA=
-github.com/noble-assets/halo/v2 v2.0.0 h1:iyeb5U7GqMeKi5s8f5dop9lRMOO4NC8wki1FiNIx0r0=
-github.com/noble-assets/halo/v2 v2.0.0/go.mod h1:DY4GCfZ/7S3IEjoJBCCh7HRTxirPBOLMVwkT0N6n3bA=
+github.com/noble-assets/halo/v2 v2.0.1 h1:nHAhTnq5dPJGelcLnKzMviXtk9x0DfMnRPv+CPoEvyA=
+github.com/noble-assets/halo/v2 v2.0.1/go.mod h1:DY4GCfZ/7S3IEjoJBCCh7HRTxirPBOLMVwkT0N6n3bA=
 github.com/nunnatsa/ginkgolinter v0.16.2 h1:8iLqHIZvN4fTLDC0Ke9tbSZVcyVHoBs0HIbnVSxfHJk=
 github.com/nunnatsa/ginkgolinter v0.16.2/go.mod h1:4tWRinDN1FeJgU+iJANW/kz7xKN5nYRAOfJDQUS9dOQ=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=


### PR DESCRIPTION
This PR bumps the Halo module responsible for issuing Hashnote's USYC to the latest patch release.

[🗒️  `v2.0.1` Release Notes 🗒️](https://github.com/noble-assets/halo/releases/tag/v2.0.1)