### PR TITLE
chore: overwrite default cometbft `timeout_commit`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,9 +72,9 @@ func NewRootCmd() *cobra.Command {
 			srvCfg := serverconfig.DefaultConfig()
 			srvCfg.MinGasPrices = "0uusdc,0ausdy,0ueure"
 			srvCfg.API.Enable = true
-			// overwrite default timeout_commit from the cometbft configuration
+			// overwrite default commit timeout from the cometbft configuration
 			cmtCfg := cmtcfg.DefaultConfig()
-			cmtCfg.Consensus.TimeoutCommit = (500 * time.Millisecond)
+			cmtCfg.Consensus.TimeoutCommit = 500 * time.Millisecond
 
 			return server.InterceptConfigsPreRunHandler(cmd, serverconfig.DefaultConfigTemplate, srvCfg, cmtCfg)
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"time"
+
 	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/config"
@@ -70,8 +72,11 @@ func NewRootCmd() *cobra.Command {
 			srvCfg := serverconfig.DefaultConfig()
 			srvCfg.MinGasPrices = "0uusdc,0ausdy,0ueure"
 			srvCfg.API.Enable = true
+			// overwrite default timeout_commit from the cometbft configuration
+			cmtCfg := cmtcfg.DefaultConfig()
+			cmtCfg.Consensus.TimeoutCommit = (500 * time.Millisecond)
 
-			return server.InterceptConfigsPreRunHandler(cmd, serverconfig.DefaultConfigTemplate, srvCfg, cmtcfg.DefaultConfig())
+			return server.InterceptConfigsPreRunHandler(cmd, serverconfig.DefaultConfigTemplate, srvCfg, cmtCfg)
 		},
 	}
 

--- a/local.sh
+++ b/local.sh
@@ -29,8 +29,6 @@ if ! [ -f .duke/data/priv_validator_state.json ]; then
 
   nobled genesis gentx validator 1000000ustake --chain-id "duke-1" --home .duke --keyring-backend test &> /dev/null
   nobled genesis collect-gentxs --home .duke &> /dev/null
-
-  sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' .duke/config/config.toml
 fi
 
 nobled start --home .duke


### PR DESCRIPTION
This PR overwrites the cometbft default `timeout_commit` from `5s` to `500ms`. 
You will be able to see this change take effect when initializing Noble (`nobled init`).

For context, `500ms` is what the current Noble validator set has manually adjusted in the `config.toml` file.