### PR TITLE
Fix typographical errors

### DIFF
--- a/e2e/cctp_receive_message_test.go
+++ b/e2e/cctp_receive_message_test.go
@@ -64,7 +64,7 @@ func TestCCTP_ReceiveMessage(t *testing.T) {
 		bCtx, bCancel := context.WithTimeout(ctx, 20*time.Second)
 		defer bCancel()
 
-		// Adding an attester to protocal
+		// Adding an attester to protocol
 		tx, err := cosmos.BroadcastTx(
 			bCtx,
 			broadcaster,

--- a/e2e/cctp_receive_message_with_caller_test.go
+++ b/e2e/cctp_receive_message_with_caller_test.go
@@ -65,7 +65,7 @@ func TestCCTP_ReceiveMessageWithCaller(t *testing.T) {
 		bCtx, bCancel := context.WithTimeout(ctx, 20*time.Second)
 		defer bCancel()
 
-		// Adding an attester to protocal
+		// Adding an attester to protocol
 		tx, err := cosmos.BroadcastTx(
 			bCtx,
 			broadcaster,

--- a/e2e/cctp_replace_deposit_for_burn_test.go
+++ b/e2e/cctp_replace_deposit_for_burn_test.go
@@ -66,7 +66,7 @@ func TestCCTP_ReplaceDepositForBurn(t *testing.T) {
 		bCtx, bCancel := context.WithTimeout(ctx, 20*time.Second)
 		defer bCancel()
 
-		// Adding an attester to protocal
+		// Adding an attester to protocol
 		tx, err := cosmos.BroadcastTx(
 			bCtx,
 			broadcaster,

--- a/readme.md
+++ b/readme.md
@@ -42,8 +42,8 @@ The Access Control table below shows the functionality tied to each privileged a
 | **Update Master Minter**                    |     x     |            |                   |                       |            |                 |                 x                |
 | **Update Owner**                            |     x     |            |                   |                       |            |                 |                 x                |
 | **Update Pauser**                           |     x     |            |                   |                       |            |                 |                 x                |
-| **Transer Tokens (tokenfactory asset)**     |     x     |      x     |         x         |           x           |      x     |        x        |                                  |
-| **Transer Tokens (non-tokenfactory asset)** |     x     |      x     |         x         |           x           |      x     |        x        |                 x                |
+| **Transfer Tokens (tokenfactory asset)**     |     x     |      x     |         x         |           x           |      x     |        x        |                                  |
+| **Transfer Tokens (non-tokenfactory asset)** |     x     |      x     |         x         |           x           |      x     |        x        |                 x                |
 
 
 ## Security Guarantees in a Permissioned Validator Set (Proof of Authority) 


### PR DESCRIPTION
- `readme.md`: Corrected the spelling of "Transfer" and other minor typos.
- `cctp_receive_message_test.go`, `cctp_replace_deposit_for_burn_test.go`, and `cctp_receive_message_with_caller_test.go`: Fixed the misspelling of "protocol".
