### PR TITLE
Typo fix cctp_replace_deposit_for_burn_test.go

### DIFF
--- a/e2e/cctp_replace_deposit_for_burn_test.go
+++ b/e2e/cctp_replace_deposit_for_burn_test.go
@@ -66,7 +66,7 @@ func TestCCTP_ReplaceDepositForBurn(t *testing.T) {
 		bCtx, bCancel := context.WithTimeout(ctx, 20*time.Second)
 		defer bCancel()
 
-		// Adding an attester to protocal
+		// Adding an attester to protocol
 		tx, err := cosmos.BroadcastTx(
 			bCtx,
 			broadcaster,


### PR DESCRIPTION
# Fix Typo in `cctp_replace_deposit_for_burn_test.go`

## Description
This pull request corrects a typo in the file `e2e/cctp_replace_deposit_for_burn_test.go`. The word "protocal" was changed to "protocol" in a code comment.

## Changes Made
- **File:** `e2e/cctp_replace_deposit_for_burn_test.go`
- **Change:** Fixed the misspelling of the word "protocol" in a comment.

## Why This Is Needed
Improving the accuracy of comments enhances the code's readability and ensures clear communication for future developers working on the codebase.

Let me know if further details or adjustments are needed!
