### PR TITLE
fix: grant missing `minter` permissions to `dollar/yield` module

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -36,6 +36,8 @@ modules:
           permissions: [ burner, minter ]
         - account: dollar
           permissions: [ burner, minter ]
+        - account: dollar/yield
+          permissions: [ minter ]
       authority: authority # Utilize our custom x/authority module.
   - name: authz
     config:


### PR DESCRIPTION
This PR addresses an issue where the Dollar/Yield module account was missing minter permissions, which prevented it from minting tokens as expected.