### PR TITLE
chore: bump forwarding module and wire ante

### DIFF
--- a/.changelog/unreleased/dependencies/481-bump-forwarding.md
+++ b/.changelog/unreleased/dependencies/481-bump-forwarding.md
@@ -1,0 +1,1 @@
+- Bump Forwarding to [`v2.0.1`](https://github.com/noble-assets/forwarding/releases/tag/v2.0.1) to add check for address lenght in forwarding and harden account check when registering. ([#481](https://github.com/noble-assets/noble/pull/481))

--- a/.changelog/unreleased/dependencies/481-bump-forwarding.md
+++ b/.changelog/unreleased/dependencies/481-bump-forwarding.md
@@ -1,1 +1,1 @@
-- Bump Forwarding to [`v2.0.1`](https://github.com/noble-assets/forwarding/releases/tag/v2.0.1) to add check for address lenght in forwarding and harden account check when registering. ([#481](https://github.com/noble-assets/noble/pull/481))
+- Bump Forwarding to [`v2.0.1`](https://github.com/noble-assets/forwarding/releases/tag/v2.0.1) to add check for address lenght and harden validation when registering accounts. ([#481](https://github.com/noble-assets/noble/pull/481))

--- a/.changelog/unreleased/dependencies/481-bump-forwarding.md
+++ b/.changelog/unreleased/dependencies/481-bump-forwarding.md
@@ -1,1 +1,1 @@
-- Bump Forwarding to [`v2.0.1`](https://github.com/noble-assets/forwarding/releases/tag/v2.0.1) to add check for address lenght and harden validation when registering accounts. ([#481](https://github.com/noble-assets/noble/pull/481))
+- Bump Forwarding to [`v2.0.1`](https://github.com/noble-assets/forwarding/releases/tag/v2.0.1) to check recipient length and harden validation when registering accounts. ([#481](https://github.com/noble-assets/noble/pull/481))

--- a/.changelog/unreleased/dependencies/481-some-new-feature.md
+++ b/.changelog/unreleased/dependencies/481-some-new-feature.md
@@ -1,0 +1,1 @@
+- Bump Forwarding to [`v2.0.1`](https://github.com/noble-assets/forwarding/releases/tag/v2.0.1) ([#481](https://github.com/noble-assets/noble/pull/481))

--- a/.changelog/unreleased/dependencies/481-some-new-feature.md
+++ b/.changelog/unreleased/dependencies/481-some-new-feature.md
@@ -1,1 +1,0 @@
-- Bump Forwarding to [`v2.0.1`](https://github.com/noble-assets/forwarding/releases/tag/v2.0.1) ([#481](https://github.com/noble-assets/noble/pull/481))

--- a/ante.go
+++ b/ante.go
@@ -24,17 +24,26 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
+	"github.com/noble-assets/forwarding/v2"
+	forwardingtypes "github.com/noble-assets/forwarding/v2/types"
 )
+
+type BankKeeper interface {
+	authtypes.BankKeeper
+	forwardingtypes.BankKeeper
+}
 
 // HandlerOptions extends the options required by the default Cosmos SDK
 // AnteHandler for our custom ante decorators.
 type HandlerOptions struct {
 	ante.HandlerOptions
-	cdc       codec.Codec
-	FTFKeeper *ftfkeeper.Keeper
-	IBCKeeper *ibckeeper.Keeper
+	cdc        codec.Codec
+	BankKeeper BankKeeper
+	FTFKeeper  *ftfkeeper.Keeper
+	IBCKeeper  *ibckeeper.Keeper
 }
 
 // NewAnteHandler extends the default Cosmos SDK AnteHandler with custom ante decorators.
@@ -74,7 +83,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
 		ante.NewValidateSigCountDecorator(options.AccountKeeper),
 		ante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
-		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
+		forwarding.NewSigVerificationDecorator(options.AccountKeeper, options.BankKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
 
 		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),

--- a/app.go
+++ b/app.go
@@ -261,14 +261,14 @@ func NewApp(
 	anteHandler, err := NewAnteHandler(HandlerOptions{
 		HandlerOptions: ante.HandlerOptions{
 			AccountKeeper:   app.AccountKeeper,
-			BankKeeper:      app.BankKeeper,
 			FeegrantKeeper:  app.FeeGrantKeeper,
 			SignModeHandler: app.txConfig.SignModeHandler(),
 			TxFeeChecker:    globalfee.TxFeeChecker(app.GlobalFeeKeeper),
 		},
-		cdc:       app.appCodec,
-		FTFKeeper: app.FTFKeeper,
-		IBCKeeper: app.IBCKeeper,
+		cdc:        app.appCodec,
+		BankKeeper: app.BankKeeper,
+		FTFKeeper:  app.FTFKeeper,
+		IBCKeeper:  app.IBCKeeper,
 	})
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/golangci/golangci-lint v1.61.0
 	github.com/monerium/module-noble/v2 v2.0.0
 	github.com/noble-assets/authority v1.0.2
-	github.com/noble-assets/forwarding/v2 v2.0.0
+	github.com/noble-assets/forwarding/v2 v2.0.1
 	github.com/noble-assets/globalfee v1.0.0
 	github.com/noble-assets/halo/v2 v2.0.1
 	github.com/noble-assets/wormhole v1.0.0-alpha.2

--- a/go.sum
+++ b/go.sum
@@ -1088,8 +1088,8 @@ github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
 github.com/noble-assets/authority v1.0.2 h1:aqcQJDyFF6n5Etm4qOAtB2yBJ1AskizevJbyKL32lJc=
 github.com/noble-assets/authority v1.0.2/go.mod h1:NeduRYMyYEZ2sep+wFenvj/LWJTB9UUYw0GPldF+Bkk=
-github.com/noble-assets/forwarding/v2 v2.0.0 h1:6iBg51yEtIlSaDzW7o5g17SvP9o1rNOUFxEPX17E6pE=
-github.com/noble-assets/forwarding/v2 v2.0.0/go.mod h1:bKHj4XWyTcJqr2/XliylHJ5Te4pTftCV0h4BpnLOmf0=
+github.com/noble-assets/forwarding/v2 v2.0.1 h1:k7Nz5GRd7V8KDF7X8k/nNJacPZeSUrlVMjk1umxEdnU=
+github.com/noble-assets/forwarding/v2 v2.0.1/go.mod h1:bKHj4XWyTcJqr2/XliylHJ5Te4pTftCV0h4BpnLOmf0=
 github.com/noble-assets/globalfee v1.0.0 h1:NUNDXd5tdzB5A/O8Em/1g+GU92E4lojH3+3lOwkbO+Y=
 github.com/noble-assets/globalfee v1.0.0/go.mod h1:DmNoTJ2LqGP4KpJuz+IEKp/5uf/3hRu3GSNBGhNUZkA=
 github.com/noble-assets/halo/v2 v2.0.1 h1:nHAhTnq5dPJGelcLnKzMviXtk9x0DfMnRPv+CPoEvyA=


### PR DESCRIPTION
- Bump the Forwarding module to version 2.0.1
- Wire the forwarding module ante handler to allow signerlessly registration of forwarding accounts.