### PR TITLE
chore: optimize `in-place-fork` script

### DIFF
--- a/local_net/in-place-fork.sh
+++ b/local_net/in-place-fork.sh
@@ -2,7 +2,6 @@
 
 alias nobled=../build/nobled
 
-# Handle termination gracefully
 cleanup() {
     echo "Stopping processes..."
     kill "$NOBLED_PID" "$TAIL_PID" "$NOBLED_PID2" 2>/dev/null
@@ -15,7 +14,6 @@ HOME1=.duke
 CHAINID="noble-1"
 PEERS="4f9df51e0800e79e0d45fd376c11236b99be4e12@99.79.58.157:26656,3402e50ad4d838b26f8341a956c7b4b8a3c61ee5@65.109.93.44:21556"
 SNAP_RPC="https://noble-rpc.polkachu.com:443"
-GENESIS="https://raw.githubusercontent.com/noble-assets/networks/refs/heads/main/mainnet/noble-1/genesis.json"
 
 UPGRADE_ARG=""
 
@@ -28,19 +26,16 @@ for arg in "$@"; do
             CHAINID="grand-1"
             PEERS="f2067cc7a23a4b2525f5f98430797b1e5c92e3aa@35.183.110.236:26656,8b22414f37d381a99ba99cd1edc5b884d43b7e53@65.109.23.114:21556"
             SNAP_RPC="https://noble-testnet-rpc.polkachu.com:443"
-            GENESIS="https://raw.githubusercontent.com/noble-assets/networks/refs/heads/main/testnet/grand-1/genesis.json"
             ;;
         -u|--trigger-testnet-upgrade)
             UPGRADE_ARG="$2"
-            shift  # Move past the upgrade argument
+            shift
             ;;
     esac
     shift
 done
 
 nobled init in-place --chain-id $CHAINID --home $HOME1
-
-wget -O $HOME1/config/genesis.json $GENESIS
 
 LATEST_HEIGHT=$(curl -s $SNAP_RPC/block | jq -r .result.block.header.height); \
 BLOCK_HEIGHT=$((LATEST_HEIGHT - 2000)); \
@@ -56,7 +51,6 @@ s|^persistent_peers *=.*|persistent_peers = \"$PEERS\"|" $HOME1/config/config.to
 nobled start --halt-height $LATEST_HEIGHT --home "$HOME1" > "$HOME1/logs.log" 2>&1 &
 NOBLED_PID=$!
 
-# Show noble logs
 tail -f "$HOME1/logs.log" &
 TAIL_PID=$!
 


### PR DESCRIPTION
Removed genesis file download  from the `in-place-fork.sh` script.
I have just now realized that pulling the genesis file is not needed when state syncing a node.