### PR TITLE
fix: ensure non-empty tx injections

### DIFF
--- a/.changelog/unreleased/bug-fixes/515-empty-injections.md
+++ b/.changelog/unreleased/bug-fixes/515-empty-injections.md
@@ -1,0 +1,1 @@
+- Ensure transaction injections from Jester are non-empty. ([#515](https://github.com/noble-assets/noble/pull/515))

--- a/.changelog/unreleased/bug-fixes/515-fix-tx-injections.md
+++ b/.changelog/unreleased/bug-fixes/515-fix-tx-injections.md
@@ -1,0 +1,1 @@
+- Properly handle empty transaction injections. ([#515](https://github.com/noble-assets/noble/pull/515))

--- a/.changelog/unreleased/bug-fixes/515-fix-tx-injections.md
+++ b/.changelog/unreleased/bug-fixes/515-fix-tx-injections.md
@@ -1,1 +1,0 @@
-- Properly handle empty transaction injections. ([#515](https://github.com/noble-assets/noble/pull/515))


### PR DESCRIPTION
This PR addresses an issue where empty `sdk.Msg`'s were unnecessarily injected into block proposals.

This occurs when the proposing validator’s instance of Jester has VAAs queued up, but a previous validator has already injected those VAAs in a prior block.

This is consensus breaking.