### PR TITLE
feat: Add GetAppStatus method for node state monitoring

### DIFF
--- a/app.go
+++ b/app.go
@@ -488,3 +488,27 @@ func (app *App) kvStoreKeys() map[string]*storetypes.KVStoreKey {
 
 	return keys
 }
+
+// GetAppStatus returns important information about the current state of the application
+// including version, block height, and chain ID. This is useful for monitoring
+// and debugging purposes.
+func (app *App) GetAppStatus() map[string]interface{} {
+	status := make(map[string]interface{})
+
+	ctx := app.BaseApp.NewContext(true)
+
+	// Get current block height
+	height := app.BaseApp.LastBlockHeight()
+
+	// Get app version
+	version := "unknown"
+	if plan, err := app.UpgradeKeeper.CurrentPlan(ctx, &upgradetypes.QueryCurrentPlanRequest{}); err == nil && plan != nil {
+		version = plan.Plan.Name
+	}
+
+	status["version"] = version
+	status["height"] = height
+	status["chain_id"] = app.BaseApp.ChainID()
+
+	return status
+}


### PR DESCRIPTION
Add GetAppStatus method to App struct that provides essential node information:
- Current version
- Block height
- Chain ID

Benefits:
- Simple interface for node monitoring
- Easy integration with monitoring tools
- Zero-risk implementation using existing methods
- Useful for node operators and developers

Implementation details:
- Returns map[string]interface{} with key metrics
- Uses existing BaseApp and UpgradeKeeper methods
- Handles errors gracefully
- No external dependencies added