### PR TITLE
feat: claim swap pools yield in upgrade handler

### DIFF
--- a/app.go
+++ b/app.go
@@ -471,6 +471,8 @@ func (app *App) RegisterUpgradeHandler() error {
 			app.ModuleManager,
 			app.Configurator(),
 			app.Logger(),
+			app.AccountKeeper.AddressCodec(),
+			app.AuthorityKeeper,
 			app.BankKeeper,
 			app.DollarKeeper,
 			app.SwapKeeper,

--- a/app.go
+++ b/app.go
@@ -471,6 +471,9 @@ func (app *App) RegisterUpgradeHandler() error {
 			app.ModuleManager,
 			app.Configurator(),
 			app.Logger(),
+			app.BankKeeper,
+			app.DollarKeeper,
+			app.SwapKeeper,
 		),
 	)
 

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -49,7 +49,7 @@ func CreateUpgradeHandler(
 			return vm, err
 		}
 
-		err = ClaimSwapPoolYield(ctx, logger, addressCodec, authorityKeeper, bankKeeper, dollarKeeper, swapKeeper)
+		err = ClaimSwapPoolsYield(ctx, logger, addressCodec, authorityKeeper, bankKeeper, dollarKeeper, swapKeeper)
 		if err != nil {
 			return vm, err
 		}
@@ -60,9 +60,9 @@ func CreateUpgradeHandler(
 	}
 }
 
-// ClaimSwapPoolYield claims the $USDN yield accrued inside the Noble Swap
+// ClaimSwapPoolsYield claims the $USDN yield accrued inside the Noble Swap
 // pools and sends it to the authority address.
-func ClaimSwapPoolYield(
+func ClaimSwapPoolsYield(
 	ctx context.Context,
 	logger log.Logger,
 	addressCodec address.Codec,


### PR DESCRIPTION
This PR adds logic to the v10 upgrade handler that claims the $USDN yield accrued by the Noble Swap pools.

This has been tested against a mainnet mirror network at block 24931000:

<img width="963" alt="Screenshot 2025-04-14 at 18 10 17" src="https://github.com/user-attachments/assets/541385ca-babb-4955-a3d9-1a18ef0d35f8" />