### PR TITLE
chore: regenerate swagger for hyperlane

### DIFF
--- a/api/gen/swagger.yaml
+++ b/api/gen/swagger.yaml
@@ -2259,10 +2259,7 @@ paths:
                           protobuf release, and it is not used for type URLs
                           beginning with
 
-                          type.googleapis.com. As of May 2023, there are no
-                          widely used type server
-
-                          implementations and no plans to implement one.
+                          type.googleapis.com.
 
 
                           Schemes other than `http`, `https` (or the empty
@@ -2460,10 +2457,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -2667,10 +2661,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -2884,10 +2875,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -3131,10 +3119,7 @@ paths:
                       protobuf release, and it is not used for type URLs
                       beginning with
 
-                      type.googleapis.com. As of May 2023, there are no widely
-                      used type server
-
-                      implementations and no plans to implement one.
+                      type.googleapis.com.
 
 
                       Schemes other than `http`, `https` (or the empty scheme)
@@ -3322,10 +3307,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -3538,10 +3520,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -3771,10 +3750,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -3983,10 +3959,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -4202,10 +4175,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -4401,10 +4371,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -4598,10 +4565,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -4788,10 +4752,7 @@ paths:
                       protobuf release, and it is not used for type URLs
                       beginning with
 
-                      type.googleapis.com. As of May 2023, there are no widely
-                      used type server
-
-                      implementations and no plans to implement one.
+                      type.googleapis.com.
 
 
                       Schemes other than `http`, `https` (or the empty scheme)
@@ -4979,10 +4940,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -5209,10 +5167,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -5405,10 +5360,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -5637,10 +5589,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -5910,10 +5859,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -6134,10 +6080,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -6396,10 +6339,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -6620,10 +6560,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -8505,10 +8442,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -10005,10 +9939,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -11486,10 +11417,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -11767,10 +11695,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -11975,10 +11900,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -12176,10 +12098,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -12398,10 +12317,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -12656,10 +12572,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -12878,10 +12791,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -13133,10 +13043,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -13349,10 +13256,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -13597,10 +13501,7 @@ paths:
                       protobuf release, and it is not used for type URLs
                       beginning with
 
-                      type.googleapis.com. As of May 2023, there are no widely
-                      used type server
-
-                      implementations and no plans to implement one.
+                      type.googleapis.com.
 
 
                       Schemes other than `http`, `https` (or the empty scheme)
@@ -13677,10 +13578,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -13902,10 +13800,7 @@ paths:
                           protobuf release, and it is not used for type URLs
                           beginning with
 
-                          type.googleapis.com. As of May 2023, there are no
-                          widely used type server
-
-                          implementations and no plans to implement one.
+                          type.googleapis.com.
 
 
                           Schemes other than `http`, `https` (or the empty
@@ -13985,10 +13880,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -14209,10 +14101,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -14312,10 +14201,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -14583,10 +14469,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -14689,10 +14572,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -15475,10 +15355,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -15909,10 +15786,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -16283,10 +16157,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -16556,10 +16427,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -16798,10 +16666,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -17065,10 +16930,7 @@ paths:
                           protobuf release, and it is not used for type URLs
                           beginning with
 
-                          type.googleapis.com. As of May 2023, there are no
-                          widely used type server
-
-                          implementations and no plans to implement one.
+                          type.googleapis.com.
 
 
                           Schemes other than `http`, `https` (or the empty
@@ -17263,10 +17125,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -17570,10 +17429,7 @@ paths:
                                 protobuf release, and it is not used for type
                                 URLs beginning with
 
-                                type.googleapis.com. As of May 2023, there are
-                                no widely used type server
-
-                                implementations and no plans to implement one.
+                                type.googleapis.com.
 
 
                                 Schemes other than `http`, `https` (or the empty
@@ -17795,10 +17651,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -18039,10 +17892,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -18251,10 +18101,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -18460,10 +18307,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -18702,10 +18546,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -18967,10 +18808,7 @@ paths:
                           protobuf release, and it is not used for type URLs
                           beginning with
 
-                          type.googleapis.com. As of May 2023, there are no
-                          widely used type server
-
-                          implementations and no plans to implement one.
+                          type.googleapis.com.
 
 
                           Schemes other than `http`, `https` (or the empty
@@ -19165,10 +19003,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -19451,10 +19286,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -19764,10 +19596,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -20037,10 +19866,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -20348,10 +20174,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -20613,10 +20436,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -20848,10 +20668,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -21087,10 +20904,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -21313,10 +21127,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -21602,10 +21413,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -21804,10 +21612,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -22015,10 +21820,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -22408,10 +22210,7 @@ paths:
                           protobuf release, and it is not used for type URLs
                           beginning with
 
-                          type.googleapis.com. As of May 2023, there are no
-                          widely used type server
-
-                          implementations and no plans to implement one.
+                          type.googleapis.com.
 
 
                           Schemes other than `http`, `https` (or the empty
@@ -22542,10 +22341,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -22788,10 +22584,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -23053,10 +22846,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -23271,10 +23061,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -23485,10 +23272,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -23731,10 +23515,7 @@ paths:
                           protobuf release, and it is not used for type URLs
                           beginning with
 
-                          type.googleapis.com. As of May 2023, there are no
-                          widely used type server
-
-                          implementations and no plans to implement one.
+                          type.googleapis.com.
 
 
                           Schemes other than `http`, `https` (or the empty
@@ -23813,10 +23594,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -24044,10 +23822,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -24276,10 +24051,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -24496,10 +24268,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -24702,10 +24471,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -24913,10 +24679,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -25117,10 +24880,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -25328,10 +25088,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -25532,10 +25289,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -25747,10 +25501,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -25958,10 +25709,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -26173,10 +25921,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -26384,10 +26129,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -26590,10 +26332,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -26806,10 +26545,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -27012,10 +26748,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -27223,10 +26956,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -27427,10 +27157,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -27631,10 +27358,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -27842,10 +27566,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -28046,10 +27767,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -28261,10 +27979,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -28472,10 +28187,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -28687,10 +28399,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -28898,10 +28607,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -29104,10 +28810,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -30084,10 +29787,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -30375,10 +30075,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -30586,10 +30283,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -30809,10 +30503,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -30941,6 +30632,624 @@ paths:
           type: string
       tags:
         - Hyperlane
+  /hyperlane/v1/registered_apps:
+    get:
+      summary: RegisteredApps ...
+      operationId: RegisteredApps
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              ids:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+            description: QueryRegisteredAppsResponse ...
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                  additionalProperties: {}
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                     Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                     Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+                    ====
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      tags:
+        - Hyperlane
+  /hyperlane/v1/registered_hooks:
+    get:
+      summary: RegisteredHooks ...
+      operationId: RegisteredHooks
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              ids:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+            description: QueryRegisteredHooksResponse ...
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                  additionalProperties: {}
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                     Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                     Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+                    ====
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      tags:
+        - Hyperlane
+  /hyperlane/v1/registered_isms:
+    get:
+      summary: RegisteredISMs ...
+      operationId: RegisteredISMs
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              ids:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+            description: QueryRegisteredISMsResponse ...
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                  additionalProperties: {}
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                     Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                     Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+                    ====
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      tags:
+        - Hyperlane
   /hyperlane/v1/verify_dry_run:
     get:
       summary: VerifyDryRun ...
@@ -31020,10 +31329,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -31158,6 +31464,10 @@ paths:
           in: query
           required: false
           type: string
+        - name: gas_limit
+          in: query
+          required: false
+          type: string
       tags:
         - Hyperlane
   /hyperlane/v1/isms:
@@ -31226,10 +31536,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -31437,10 +31744,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -31684,10 +31988,7 @@ paths:
                       protobuf release, and it is not used for type URLs
                       beginning with
 
-                      type.googleapis.com. As of May 2023, there are no widely
-                      used type server
-
-                      implementations and no plans to implement one.
+                      type.googleapis.com.
 
 
                       Schemes other than `http`, `https` (or the empty scheme)
@@ -31873,10 +32174,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -32086,10 +32384,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -32301,10 +32596,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -33741,10 +34033,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -34086,10 +34375,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -34370,10 +34656,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -34590,10 +34873,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -34909,10 +35189,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -35158,10 +35435,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -35401,10 +35675,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -35644,10 +35915,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -35901,10 +36169,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -36298,10 +36563,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -36571,10 +36833,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -36795,10 +37054,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -37053,10 +37309,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -37275,10 +37528,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -37505,10 +37755,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -37735,10 +37982,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -38100,10 +38344,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -38496,10 +38737,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -38710,10 +38948,7 @@ paths:
                           protobuf release, and it is not used for type URLs
                           beginning with
 
-                          type.googleapis.com. As of May 2023, there are no
-                          widely used type server
-
-                          implementations and no plans to implement one.
+                          type.googleapis.com.
 
 
                           Schemes other than `http`, `https` (or the empty
@@ -38949,10 +39184,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -39153,10 +39385,7 @@ paths:
                       protobuf release, and it is not used for type URLs
                       beginning with
 
-                      type.googleapis.com. As of May 2023, there are no widely
-                      used type server
-
-                      implementations and no plans to implement one.
+                      type.googleapis.com.
 
 
                       Schemes other than `http`, `https` (or the empty scheme)
@@ -39387,10 +39616,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -39662,10 +39888,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -39923,10 +40146,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -40238,10 +40458,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -40568,10 +40785,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -40887,10 +41101,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -41206,10 +41417,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -41479,10 +41687,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -41755,10 +41960,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -42030,10 +42232,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -42400,10 +42599,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -42673,10 +42869,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -43049,10 +43242,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -43379,10 +43569,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -43579,10 +43766,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -43812,10 +43996,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -44060,10 +44241,7 @@ paths:
                       protobuf release, and it is not used for type URLs
                       beginning with
 
-                      type.googleapis.com. As of May 2023, there are no widely
-                      used type server
-
-                      implementations and no plans to implement one.
+                      type.googleapis.com.
 
 
                       Schemes other than `http`, `https` (or the empty scheme)
@@ -44296,10 +44474,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -44512,10 +44687,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -44753,10 +44925,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -44984,10 +45153,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -45328,10 +45494,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -45587,10 +45750,7 @@ paths:
                       protobuf release, and it is not used for type URLs
                       beginning with
 
-                      type.googleapis.com. As of May 2023, there are no widely
-                      used type server
-
-                      implementations and no plans to implement one.
+                      type.googleapis.com.
 
 
                       Schemes other than `http`, `https` (or the empty scheme)
@@ -45820,10 +45980,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -46072,10 +46229,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -46263,10 +46417,7 @@ paths:
                       protobuf release, and it is not used for type URLs
                       beginning with
 
-                      type.googleapis.com. As of May 2023, there are no widely
-                      used type server
-
-                      implementations and no plans to implement one.
+                      type.googleapis.com.
 
 
                       Schemes other than `http`, `https` (or the empty scheme)
@@ -46454,10 +46605,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -46645,10 +46793,7 @@ paths:
                       protobuf release, and it is not used for type URLs
                       beginning with
 
-                      type.googleapis.com. As of May 2023, there are no widely
-                      used type server
-
-                      implementations and no plans to implement one.
+                      type.googleapis.com.
 
 
                       Schemes other than `http`, `https` (or the empty scheme)
@@ -46836,10 +46981,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -47047,10 +47189,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -47366,10 +47505,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -47732,10 +47868,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -48133,10 +48266,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -48340,10 +48470,7 @@ paths:
                           protobuf release, and it is not used for type URLs
                           beginning with
 
-                          type.googleapis.com. As of May 2023, there are no
-                          widely used type server
-
-                          implementations and no plans to implement one.
+                          type.googleapis.com.
 
 
                           Schemes other than `http`, `https` (or the empty
@@ -48579,10 +48706,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -48778,10 +48902,7 @@ paths:
                       protobuf release, and it is not used for type URLs
                       beginning with
 
-                      type.googleapis.com. As of May 2023, there are no widely
-                      used type server
-
-                      implementations and no plans to implement one.
+                      type.googleapis.com.
 
 
                       Schemes other than `http`, `https` (or the empty scheme)
@@ -49012,10 +49133,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -49250,10 +49368,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -49454,10 +49569,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -49658,10 +49770,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -49874,10 +49983,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -50127,10 +50233,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -50347,10 +50450,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -51234,10 +51334,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -51453,10 +51550,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -51686,10 +51780,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -51911,10 +52002,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -52204,10 +52292,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -52422,10 +52507,7 @@ paths:
                             protobuf release, and it is not used for type URLs
                             beginning with
 
-                            type.googleapis.com. As of May 2023, there are no
-                            widely used type server
-
-                            implementations and no plans to implement one.
+                            type.googleapis.com.
 
 
                             Schemes other than `http`, `https` (or the empty
@@ -52556,10 +52638,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -52772,10 +52851,7 @@ paths:
                           protobuf release, and it is not used for type URLs
                           beginning with
 
-                          type.googleapis.com. As of May 2023, there are no
-                          widely used type server
-
-                          implementations and no plans to implement one.
+                          type.googleapis.com.
 
 
                           Schemes other than `http`, `https` (or the empty
@@ -52903,10 +52979,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -53139,10 +53212,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -53380,10 +53450,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -53651,10 +53718,7 @@ paths:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -55483,10 +55547,7 @@ definitions:
 
           protobuf release, and it is not used for type URLs beginning with
 
-          type.googleapis.com. As of May 2023, there are no widely used type
-          server
-
-          implementations and no plans to implement one.
+          type.googleapis.com.
 
 
           Schemes other than `http`, `https` (or the empty scheme) might be
@@ -55656,10 +55717,7 @@ definitions:
                 protobuf release, and it is not used for type URLs beginning
                 with
 
-                type.googleapis.com. As of May 2023, there are no widely used
-                type server
-
-                implementations and no plans to implement one.
+                type.googleapis.com.
 
 
                 Schemes other than `http`, `https` (or the empty scheme) might
@@ -56137,10 +56195,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -56362,10 +56417,7 @@ definitions:
                   protobuf release, and it is not used for type URLs beginning
                   with
 
-                  type.googleapis.com. As of May 2023, there are no widely used
-                  type server
-
-                  implementations and no plans to implement one.
+                  type.googleapis.com.
 
 
                   Schemes other than `http`, `https` (or the empty scheme) might
@@ -56542,10 +56594,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -56714,10 +56763,7 @@ definitions:
                 protobuf release, and it is not used for type URLs beginning
                 with
 
-                type.googleapis.com. As of May 2023, there are no widely used
-                type server
-
-                implementations and no plans to implement one.
+                type.googleapis.com.
 
 
                 Schemes other than `http`, `https` (or the empty scheme) might
@@ -56908,10 +56954,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -57080,10 +57123,7 @@ definitions:
                 protobuf release, and it is not used for type URLs beginning
                 with
 
-                type.googleapis.com. As of May 2023, there are no widely used
-                type server
-
-                implementations and no plans to implement one.
+                type.googleapis.com.
 
 
                 Schemes other than `http`, `https` (or the empty scheme) might
@@ -57277,10 +57317,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -57460,10 +57497,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -57647,10 +57681,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -57863,10 +57894,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -58075,10 +58103,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -62316,10 +62341,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -62614,10 +62636,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -62982,10 +63001,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -65894,10 +65910,7 @@ definitions:
                 protobuf release, and it is not used for type URLs beginning
                 with
 
-                type.googleapis.com. As of May 2023, there are no widely used
-                type server
-
-                implementations and no plans to implement one.
+                type.googleapis.com.
 
 
                 Schemes other than `http`, `https` (or the empty scheme) might
@@ -66088,10 +66101,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -66164,10 +66174,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -66244,10 +66251,7 @@ definitions:
                   protobuf release, and it is not used for type URLs beginning
                   with
 
-                  type.googleapis.com. As of May 2023, there are no widely used
-                  type server
-
-                  implementations and no plans to implement one.
+                  type.googleapis.com.
 
 
                   Schemes other than `http`, `https` (or the empty scheme) might
@@ -66331,10 +66335,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -66441,10 +66442,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -67065,10 +67063,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -67520,10 +67515,7 @@ definitions:
                   protobuf release, and it is not used for type URLs beginning
                   with
 
-                  type.googleapis.com. As of May 2023, there are no widely used
-                  type server
-
-                  implementations and no plans to implement one.
+                  type.googleapis.com.
 
 
                   Schemes other than `http`, `https` (or the empty scheme) might
@@ -67711,10 +67703,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -68036,10 +68025,7 @@ definitions:
                         protobuf release, and it is not used for type URLs
                         beginning with
 
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
+                        type.googleapis.com.
 
 
                         Schemes other than `http`, `https` (or the empty scheme)
@@ -68584,10 +68570,7 @@ definitions:
                   protobuf release, and it is not used for type URLs beginning
                   with
 
-                  type.googleapis.com. As of May 2023, there are no widely used
-                  type server
-
-                  implementations and no plans to implement one.
+                  type.googleapis.com.
 
 
                   Schemes other than `http`, `https` (or the empty scheme) might
@@ -68854,10 +68837,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -69433,10 +69413,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -69735,10 +69712,7 @@ definitions:
                 protobuf release, and it is not used for type URLs beginning
                 with
 
-                type.googleapis.com. As of May 2023, there are no widely used
-                type server
-
-                implementations and no plans to implement one.
+                type.googleapis.com.
 
 
                 Schemes other than `http`, `https` (or the empty scheme) might
@@ -70009,10 +69983,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -70444,10 +70415,7 @@ definitions:
                   protobuf release, and it is not used for type URLs beginning
                   with
 
-                  type.googleapis.com. As of May 2023, there are no widely used
-                  type server
-
-                  implementations and no plans to implement one.
+                  type.googleapis.com.
 
 
                   Schemes other than `http`, `https` (or the empty scheme) might
@@ -71369,10 +71337,7 @@ definitions:
                   protobuf release, and it is not used for type URLs beginning
                   with
 
-                  type.googleapis.com. As of May 2023, there are no widely used
-                  type server
-
-                  implementations and no plans to implement one.
+                  type.googleapis.com.
 
 
                   Schemes other than `http`, `https` (or the empty scheme) might
@@ -71582,10 +71547,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -71938,10 +71900,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -72113,10 +72072,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -72329,10 +72285,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -72539,10 +72492,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -72722,10 +72672,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -72925,10 +72872,7 @@ definitions:
                 protobuf release, and it is not used for type URLs beginning
                 with
 
-                type.googleapis.com. As of May 2023, there are no widely used
-                type server
-
-                implementations and no plans to implement one.
+                type.googleapis.com.
 
 
                 Schemes other than `http`, `https` (or the empty scheme) might
@@ -73125,10 +73069,7 @@ definitions:
                 protobuf release, and it is not used for type URLs beginning
                 with
 
-                type.googleapis.com. As of May 2023, there are no widely used
-                type server
-
-                implementations and no plans to implement one.
+                type.googleapis.com.
 
 
                 Schemes other than `http`, `https` (or the empty scheme) might
@@ -73300,10 +73241,7 @@ definitions:
                 protobuf release, and it is not used for type URLs beginning
                 with
 
-                type.googleapis.com. As of May 2023, there are no widely used
-                type server
-
-                implementations and no plans to implement one.
+                type.googleapis.com.
 
 
                 Schemes other than `http`, `https` (or the empty scheme) might
@@ -73657,10 +73595,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -73797,10 +73732,7 @@ definitions:
                   protobuf release, and it is not used for type URLs beginning
                   with
 
-                  type.googleapis.com. As of May 2023, there are no widely used
-                  type server
-
-                  implementations and no plans to implement one.
+                  type.googleapis.com.
 
 
                   Schemes other than `http`, `https` (or the empty scheme) might
@@ -74251,6 +74183,33 @@ definitions:
       ism_id:
         type: string
     description: QueryRecipientIsmResponse ...
+  hyperlane.core.v1.QueryRegisteredAppsResponse:
+    type: object
+    properties:
+      ids:
+        type: array
+        items:
+          type: integer
+          format: int64
+    description: QueryRegisteredAppsResponse ...
+  hyperlane.core.v1.QueryRegisteredHooksResponse:
+    type: object
+    properties:
+      ids:
+        type: array
+        items:
+          type: integer
+          format: int64
+    description: QueryRegisteredHooksResponse ...
+  hyperlane.core.v1.QueryRegisteredISMsResponse:
+    type: object
+    properties:
+      ids:
+        type: array
+        items:
+          type: integer
+          format: int64
+    description: QueryRegisteredISMsResponse ...
   hyperlane.core.v1.QueryVerifyDryRunResponse:
     type: object
     properties:
@@ -74317,10 +74276,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -74487,10 +74443,7 @@ definitions:
                 protobuf release, and it is not used for type URLs beginning
                 with
 
-                type.googleapis.com. As of May 2023, there are no widely used
-                type server
-
-                implementations and no plans to implement one.
+                type.googleapis.com.
 
 
                 Schemes other than `http`, `https` (or the empty scheme) might
@@ -76486,10 +76439,7 @@ definitions:
                   protobuf release, and it is not used for type URLs beginning
                   with
 
-                  type.googleapis.com. As of May 2023, there are no widely used
-                  type server
-
-                  implementations and no plans to implement one.
+                  type.googleapis.com.
 
 
                   Schemes other than `http`, `https` (or the empty scheme) might
@@ -76702,10 +76652,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -78407,10 +78354,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -78612,10 +78556,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -78825,10 +78766,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -79050,10 +78988,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -79351,10 +79286,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -79607,10 +79539,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)
@@ -79816,10 +79745,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -79986,10 +79912,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -80520,10 +80443,7 @@ definitions:
                   protobuf release, and it is not used for type URLs beginning
                   with
 
-                  type.googleapis.com. As of May 2023, there are no widely used
-                  type server
-
-                  implementations and no plans to implement one.
+                  type.googleapis.com.
 
 
                   Schemes other than `http`, `https` (or the empty scheme) might
@@ -80736,10 +80656,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -81829,10 +81746,7 @@ definitions:
 
               protobuf release, and it is not used for type URLs beginning with
 
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
+              type.googleapis.com.
 
 
               Schemes other than `http`, `https` (or the empty scheme) might be
@@ -81971,10 +81885,7 @@ definitions:
                   protobuf release, and it is not used for type URLs beginning
                   with
 
-                  type.googleapis.com. As of May 2023, there are no widely used
-                  type server
-
-                  implementations and no plans to implement one.
+                  type.googleapis.com.
 
 
                   Schemes other than `http`, `https` (or the empty scheme) might
@@ -82119,10 +82030,7 @@ definitions:
                     protobuf release, and it is not used for type URLs beginning
                     with
 
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
+                    type.googleapis.com.
 
 
                     Schemes other than `http`, `https` (or the empty scheme)

--- a/api/generate.sh
+++ b/api/generate.sh
@@ -3,7 +3,7 @@ rm -rf ./api/proto
 rm -rf ./api/tmp-swagger-gen
 
 # IMPORTANT: These versions should match the go.mod!
-buf export buf.build/bcp-innovations/hyperlane-cosmos:v1.0.0-beta0 --output api/proto
+buf export buf.build/bcp-innovations/hyperlane-cosmos:v1.0.0 --output api/proto
 buf export buf.build/cosmos/cosmos-sdk:v0.50.0 --output api/proto
 buf export buf.build/cosmos/ibc:e69c8f372b127401762cb251bb7b60371b4cef29 --output api/proto
 buf export buf.build/noble-assets/aura:v2.0.0 --output api/proto


### PR DESCRIPTION
Through multiple PRs, we bumped the version of the Hyperlane dependency to `v1.0.0`, but never updated the Swagger file.