### PR TITLE
chore: revert upgrade name change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/noble-assets/noble/v10
 
 go 1.24
 
-retract v10.0.0-beta.0
-
 require (
 	autocctp.dev v1.0.0-beta.0
 	connectrpc.com/connect v1.18.1

--- a/upgrade/constants.go
+++ b/upgrade/constants.go
@@ -17,7 +17,7 @@
 package upgrade
 
 // UpgradeName is the name of this specific software upgrade used on-chain.
-const UpgradeName = "stratrum"
+const UpgradeName = "stratum"
 
 // UpgradeASCII is the ASCII art shown to node operators upon successful upgrade.
 const UpgradeASCII = `


### PR DESCRIPTION
This reverts commit #542, as we will use the correct upgrade name for mainnet.