### PR TITLE
chore: create default hook for hyperlane mailbox

### DIFF
--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -194,6 +194,15 @@ func InitializeHyperlaneModule(
 	mailboxId := createMailboxRes.Id
 	logger.Info("created noble hyperlane mailbox", "id", mailboxId)
 
+	createNoopHookRes, err := pdhServer.CreateNoopHook(ctx, &pdhtypes.MsgCreateNoopHook{
+		Owner: authority,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create noop hook: %w", err)
+	}
+	defaultHook := createNoopHookRes.Id
+	logger.Info("created noble hyperlane noop hook", "id", defaultHook)
+
 	createMerkleTreeHookRes, err := pdhServer.CreateMerkleTreeHook(ctx, &pdhtypes.MsgCreateMerkleTreeHook{
 		Owner:     authority,
 		MailboxId: mailboxId,
@@ -207,6 +216,7 @@ func InitializeHyperlaneModule(
 	_, err = hyperlaneServer.SetMailbox(ctx, &hyperlanetypes.MsgSetMailbox{
 		Owner:        authority,
 		MailboxId:    mailboxId,
+		DefaultHook:  &defaultHook,
 		RequiredHook: &requiredHook,
 	})
 	if err != nil {


### PR DESCRIPTION
Although the `DefaultHook` field inside a Hyperlane Mailbox can be empty, messages can't be sent without it being set. For now, we will set this to a noop hook as the IGP hooks will be used depending on the token being transferred 😄

[Transaction on testnet failing because of this](https://www.mintscan.io/noble-testnet/tx/922DB201738923B67039A114EB1F55876D52251065783A02AF710B2B25F082AA?height=29537722)