### PR TITLE
chore: re-add stratum upgrade handler

### DIFF
--- a/app.go
+++ b/app.go
@@ -467,6 +467,14 @@ func (app *App) RegisterUpgradeHandler() error {
 		upgrade.CreateUpgradeHandler(
 			app.ModuleManager,
 			app.Configurator(),
+			app.Logger(),
+			app.AccountKeeper.AddressCodec(),
+			app.AuthorityKeeper,
+			app.BankKeeper,
+			app.IBCKeeper.ClientKeeper,
+			app.DollarKeeper,
+			app.HyperlaneKeeper,
+			app.SwapKeeper,
 		),
 	)
 

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -27,12 +27,12 @@ func TestChainUpgrade(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	genesisVersion := "v10.0.0-rc.2"
+	genesisVersion := "v9.0.4"
 
 	upgrades := []e2e.ChainUpgrade{
 		{
 			Image:       e2e.LocalImages[0],
-			UpgradeName: "v10.0.0-rc.3",
+			UpgradeName: "stratum",
 		},
 	}
 

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -431,7 +431,7 @@ func NobleSpinUp(t *testing.T, ctx context.Context, version []ibc.DockerImage, s
 	numFullNodes := 0
 
 	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
-		NobleChainSpec(ctx, &nw, "grand-1", version, numValidators, numFullNodes, setupAllCircleRoles),
+		NobleChainSpec(ctx, &nw, "noble-1", version, numValidators, numFullNodes, setupAllCircleRoles),
 	})
 
 	chains, err := cf.Chains(t.Name())
@@ -485,10 +485,10 @@ func NobleSpinUpIBC(t *testing.T, ctx context.Context, version []ibc.DockerImage
 	numFullNodes := 0
 
 	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
-		NobleChainSpec(ctx, &nw, "grand-1", version, numValidators, numFullNodes, setupAllCircleRoles),
+		NobleChainSpec(ctx, &nw, "noble-1", version, numValidators, numFullNodes, setupAllCircleRoles),
 		{
 			Name:    "ibc-go-simd",
-			Version: "v8.5.1",
+			Version: "v8.7.0",
 			ChainConfig: ibc.ChainConfig{
 				EncodingConfig: SimdEncoding(),
 			},

--- a/upgrade/constants.go
+++ b/upgrade/constants.go
@@ -17,10 +17,32 @@
 package upgrade
 
 // UpgradeName is the name of this specific software upgrade used on-chain.
-const UpgradeName = "v10.0.0-rc.3"
+const UpgradeName = "stratum"
+
+// UpgradeASCII is the ASCII art shown to node operators upon successful upgrade.
+const UpgradeASCII = `
+
+	███████╗████████╗██████╗  █████╗ ████████╗██╗   ██╗███╗   ███╗
+	██╔════╝╚══██╔══╝██╔══██╗██╔══██╗╚══██╔══╝██║   ██║████╗ ████║
+	███████╗   ██║   ██████╔╝███████║   ██║   ██║   ██║██╔████╔██║
+	╚════██║   ██║   ██╔══██╗██╔══██║   ██║   ██║   ██║██║╚██╔╝██║
+	███████║   ██║   ██║  ██║██║  ██║   ██║   ╚██████╔╝██║ ╚═╝ ██║
+	╚══════╝   ╚═╝   ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝    ╚═════╝ ╚═╝     ╚═╝
+
+`
 
 // TestnetChainID is the Chain ID of the Noble testnet.
 const TestnetChainID = "grand-1"
 
+// TestnetHyperlaneDomain is the Hyperlane domain of the Noble testnet.
+// Generated from: console.log(parseInt('0x'+Buffer.from('GRAN').toString('hex')))
+// We truncate "GRAND" to "GRAN" to not exceed the uint32 maximum.
+const TestnetHyperlaneDomain = 1196573006
+
 // MainnetChainID is the Chain ID of the Noble mainnet.
 const MainnetChainID = "noble-1"
+
+// MainnetHyperlaneDomain is the Hyperlane domain of the Noble mainnet.
+// Generated from: console.log(parseInt('0x'+Buffer.from('NOBL').toString('hex')))
+// We truncate "NOBLE" to "NOBL" to not exceed the uint32 maximum.
+const MainnetHyperlaneDomain = 1313817164

--- a/upgrade/store.go
+++ b/upgrade/store.go
@@ -19,11 +19,22 @@ package upgrade
 import (
 	storetypes "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+	hyperlanetypes "github.com/bcp-innovations/hyperlane-cosmos/x/core/types"
+	warptypes "github.com/bcp-innovations/hyperlane-cosmos/x/warp/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v8/types"
 )
 
 func CreateStoreLoader(upgradeHeight int64) baseapp.StoreLoader {
-	storeUpgrades := storetypes.StoreUpgrades{}
+	storeUpgrades := storetypes.StoreUpgrades{
+		Added: []string{
+			// Hyperlane Modules
+			hyperlanetypes.ModuleName,
+			warptypes.ModuleName,
+			// IBC Modules
+			ratelimittypes.ModuleName,
+		},
+	}
 
 	return upgradetypes.UpgradeStoreLoader(upgradeHeight, &storeUpgrades)
 }

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -18,24 +18,198 @@ package upgrade
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"cosmossdk.io/core/address"
+	"cosmossdk.io/log"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+	dollarkeeper "dollar.noble.xyz/v2/keeper"
+	dollartypes "dollar.noble.xyz/v2/types"
+	ismkeeper "github.com/bcp-innovations/hyperlane-cosmos/x/core/01_interchain_security/keeper"
+	ismtypes "github.com/bcp-innovations/hyperlane-cosmos/x/core/01_interchain_security/types"
+	pdhkeeper "github.com/bcp-innovations/hyperlane-cosmos/x/core/02_post_dispatch/keeper"
+	pdhtypes "github.com/bcp-innovations/hyperlane-cosmos/x/core/02_post_dispatch/types"
+	hyperlanekeeper "github.com/bcp-innovations/hyperlane-cosmos/x/core/keeper"
+	hyperlanetypes "github.com/bcp-innovations/hyperlane-cosmos/x/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	clientkeeper "github.com/cosmos/ibc-go/v8/modules/core/02-client/keeper"
+	authoritykeeper "github.com/noble-assets/authority/keeper"
+	authoritytypes "github.com/noble-assets/authority/types"
+	swapkeeper "swap.noble.xyz/keeper"
 )
 
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	cfg module.Configurator,
+	logger log.Logger,
+	addressCodec address.Codec,
+	authorityKeeper *authoritykeeper.Keeper,
+	bankKeeper bankkeeper.Keeper,
+	clientKeeper clientkeeper.Keeper,
+	dollarKeeper *dollarkeeper.Keeper,
+	hyperlaneKeeper *hyperlanekeeper.Keeper,
+	swapKeeper *swapkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		sdkCtx := sdk.UnwrapSDKContext(ctx)
-		chainID := sdkCtx.ChainID()
-		if chainID != TestnetChainID {
-			return vm, fmt.Errorf("%s upgrade not allowed to execute on %s chain", UpgradeName, chainID)
+
+		vm, err := mm.RunMigrations(ctx, cfg, vm)
+		if err != nil {
+			return vm, err
 		}
 
-		return mm.RunMigrations(ctx, cfg, vm)
+		err = ClaimSwapPoolsYield(ctx, logger, addressCodec, authorityKeeper, bankKeeper, dollarKeeper, swapKeeper)
+		if err != nil {
+			return vm, err
+		}
+
+		err = InitializeHyperlaneModule(ctx, logger, addressCodec, hyperlaneKeeper)
+		if err != nil {
+			return vm, err
+		}
+
+		// The IBC light client for the router_9600-1 chain has expired on
+		// Noble's mainnet. In IBC-Go v8.7.0, the MsgRecoverClient message does
+		// not support the LegacyAminoJSON signing mode, preventing recovery
+		// via the Noble Maintenance Multisig. As a result, the client must be
+		// manually recovered as part of this software upgrade.
+		if sdkCtx.ChainID() == MainnetChainID {
+			err = clientKeeper.RecoverClient(sdkCtx, "07-tendermint-136", "07-tendermint-161")
+			if err != nil {
+				return vm, err
+			}
+		}
+
+		logger.Info(UpgradeASCII)
+
+		return vm, nil
 	}
+}
+
+// ClaimSwapPoolsYield claims the $USDN yield accrued inside the Noble Swap
+// pools and sends it to the authority address.
+func ClaimSwapPoolsYield(
+	ctx context.Context,
+	logger log.Logger,
+	addressCodec address.Codec,
+	authorityKeeper *authoritykeeper.Keeper,
+	bankKeeper bankkeeper.Keeper,
+	dollarKeeper *dollarkeeper.Keeper,
+	swapKeeper *swapkeeper.Keeper,
+) error {
+	authority, err := authorityKeeper.Owner.Get(ctx)
+	if err != nil {
+		return errors.New("unable to get underlying authority address from state")
+	}
+	authorityBz, err := addressCodec.StringToBytes(authority)
+	if err != nil {
+		return errors.New("unable to decode underlying authority address")
+	}
+
+	dollarServer := dollarkeeper.NewMsgServer(dollarKeeper)
+
+	pools := swapKeeper.GetPools(ctx)
+	for _, pool := range pools {
+		yield, address, err := dollarKeeper.GetYield(ctx, pool.Address)
+		if err != nil {
+			return fmt.Errorf("unable to get yield for pool %d", pool.Id)
+		}
+
+		_, err = dollarServer.ClaimYield(ctx, &dollartypes.MsgClaimYield{Signer: pool.Address})
+		if err != nil {
+			return fmt.Errorf("unable to claim yield for pool %d", pool.Id)
+		}
+
+		err = bankKeeper.SendCoins(ctx, address, authorityBz, sdk.NewCoins(sdk.NewCoin(dollarKeeper.GetDenom(), yield)))
+		if err != nil {
+			return fmt.Errorf("unable to transfer yield for pool %d", pool.Id)
+		}
+
+		logger.Info("claimed swap pool yield", "pool", pool.Id, "yield", yield)
+	}
+
+	return nil
+}
+
+// InitializeHyperlaneModule creates a default Hyperlane ISM and Mailbox.
+func InitializeHyperlaneModule(
+	ctx context.Context,
+	logger log.Logger,
+	addressCodec address.Codec,
+	hyperlaneKeeper *hyperlanekeeper.Keeper,
+) error {
+	chainId := sdk.UnwrapSDKContext(ctx).ChainID()
+
+	var localDomain uint32
+	switch chainId {
+	case TestnetChainID:
+		localDomain = TestnetHyperlaneDomain
+	case MainnetChainID:
+		localDomain = MainnetHyperlaneDomain
+	default:
+		return fmt.Errorf("cannot initialize hyperlane module on %s chain", chainId)
+	}
+
+	authority, err := addressCodec.BytesToString(authoritytypes.ModuleAddress)
+	if err != nil {
+		return errors.New("unable to encode authority address")
+	}
+
+	ismServer := ismkeeper.NewMsgServerImpl(&hyperlaneKeeper.IsmKeeper)
+	pdhServer := pdhkeeper.NewMsgServerImpl(&hyperlaneKeeper.PostDispatchKeeper)
+	hyperlaneServer := hyperlanekeeper.NewMsgServerImpl(hyperlaneKeeper)
+
+	createRoutingIsmRes, err := ismServer.CreateRoutingIsm(ctx, &ismtypes.MsgCreateRoutingIsm{
+		Creator: authority,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create routing ism: %w", err)
+	}
+	ismId := createRoutingIsmRes.Id
+	logger.Info("created default hyperlane ism", "id", ismId)
+
+	createMailboxRes, err := hyperlaneServer.CreateMailbox(ctx, &hyperlanetypes.MsgCreateMailbox{
+		Owner:       authority,
+		LocalDomain: localDomain,
+		DefaultIsm:  ismId,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create mailbox: %w", err)
+	}
+	mailboxId := createMailboxRes.Id
+	logger.Info("created default hyperlane mailbox", "id", mailboxId)
+
+	createMerkleTreeHookRes, err := pdhServer.CreateMerkleTreeHook(ctx, &pdhtypes.MsgCreateMerkleTreeHook{
+		Owner:     authority,
+		MailboxId: mailboxId,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create merkle tree hook: %w", err)
+	}
+	requiredHook := createMerkleTreeHookRes.Id
+	logger.Info("created required hook for default hyperlane mailbox", "id", requiredHook)
+
+	createNoopHookRes, err := pdhServer.CreateNoopHook(ctx, &pdhtypes.MsgCreateNoopHook{
+		Owner: authority,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create noop hook: %w", err)
+	}
+	defaultHook := createNoopHookRes.Id
+	logger.Info("created default hook for default hyperlane mailbox", "id", defaultHook)
+
+	_, err = hyperlaneServer.SetMailbox(ctx, &hyperlanetypes.MsgSetMailbox{
+		Owner:        authority,
+		MailboxId:    mailboxId,
+		DefaultHook:  &defaultHook,
+		RequiredHook: &requiredHook,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to set mailbox: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Now that the `v10.0.0-rc.0` upgrade has been successfully executed on Noble's Testnet, we can re-add the v10 Stratum upgrade handler with any additional changes in preparation for the upgrade on Noble's Mainnet!