### PR TITLE
fix: register ibc middleware from dollar module

### DIFF
--- a/legacy.go
+++ b/legacy.go
@@ -148,6 +148,7 @@ func (app *App) RegisterLegacyModules() error {
 		pfmkeeper.DefaultForwardTransferPacketTimeoutTimestamp,
 	)
 	transferStack = blockibc.NewIBCMiddleware(transferStack, app.FTFKeeper)
+	transferStack = dollar.NewIBCModule(transferStack, app.DollarKeeper)
 
 	ibcRouter := porttypes.NewRouter().
 		AddRoute(icahosttypes.SubModuleName, icahost.NewIBCModule(app.ICAHostKeeper)).


### PR DESCRIPTION
This allows for us to track IBC timeouts of yield distribution and put them in the `retry_amounts` state.