### PR TITLE
fix: bump heighliner fork with musl proxy

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -30,9 +30,9 @@ jobs:
       - name: Build and push Docker image
         uses: strangelove-ventures/heighliner-build-action@v1.0.3
         with:
-          # Heighliner fork supporting Go v1.24
+          # Heighliner fork supporting Go v1.24 and musl.cc proxy
           heighliner-owner: 'noble-assets'
-          heighliner-tag: 'v1.7.3'
+          heighliner-tag: 'v1.7.4'
 
           # Heighliner chains.yaml config
           chain: noble

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -30,9 +30,9 @@ jobs:
       - name: Build and push Docker image
         uses: strangelove-ventures/heighliner-build-action@v1.0.3
         with:
-          # Heighliner fork supporting Go v1.24
+          # Heighliner fork supporting Go v1.24 and musl.cc proxy
           heighliner-owner: 'noble-assets'
-          heighliner-tag: 'v1.7.3'
+          heighliner-tag: 'v1.7.4'
 
           # Heighliner chains.yaml config
           chain: noble

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -23,9 +23,9 @@ jobs:
           platform: linux/amd64 # test runner architecture only
           git-ref: ${{ github.head_ref }} # source code ref
 
-          # Heighliner fork supporting Go v1.24
+          # Heighliner fork supporting Go v1.24 and musl.cc proxy
           heighliner-owner: 'noble-assets'
-          heighliner-tag: 'v1.7.3'
+          heighliner-tag: 'v1.7.4'
 
           # Heighliner chains.yaml config
           chain: noble


### PR DESCRIPTION
This is a temporary solution to the issues we've been running into with Heighliner in GitHub Actions ever since [musl.cc](https://musl.cc) blocked GitHub Action runners. The long term solution to this is removing Heighliner entirely which is WIP in #557 😄