### PR TITLE
Fix broken link to interchaintest folder in e2e/readme.md

### DIFF
--- a/e2e/readme.md
+++ b/e2e/readme.md
@@ -3,7 +3,7 @@
 
 We utilize the [interchaintest](https://github.com/strangelove-ventures/interchaintest) testing suite.
 
-All tests are located in the [interchaintest folder](../interchaintest/).
+All tests are located in the [e2e folder](./).
 
 ## How to Run tests:
 


### PR DESCRIPTION
The previous link to the "interchaintest" folder was incorrect, as such a folder does not exist in the repository. Updated the documentation to point to the correct "e2e" folder where all tests are actually located. This improves clarity for contributors and prevents confusion when navigating the test suite.