### PR TITLE
feat: claim `x/distribution` module funds via upgrade handler

### DIFF
--- a/app.go
+++ b/app.go
@@ -468,6 +468,9 @@ func (app *App) RegisterUpgradeHandler() error {
 			app.ModuleManager,
 			app.Configurator(),
 			app.Logger(),
+			app.AccountKeeper.AddressCodec(),
+			app.AuthorityKeeper,
+			app.BankKeeper,
 		),
 	)
 

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -18,19 +18,32 @@ package upgrade
 
 import (
 	"context"
+	"errors"
 
+	"cosmossdk.io/core/address"
 	"cosmossdk.io/log"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	authoritykeeper "github.com/noble-assets/authority/keeper"
 )
 
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	cfg module.Configurator,
 	logger log.Logger,
+	addressCodec address.Codec,
+	authorityKeeper *authoritykeeper.Keeper,
+	bankKeeper bankkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		vm, err := mm.RunMigrations(ctx, cfg, vm)
+		if err != nil {
+			return vm, err
+		}
+
+		err = ClaimDistributionFunds(ctx, logger, addressCodec, authorityKeeper, bankKeeper)
 		if err != nil {
 			return vm, err
 		}
@@ -39,4 +52,36 @@ func CreateUpgradeHandler(
 
 		return vm, nil
 	}
+}
+
+// ClaimDistributionFunds transfers all transaction fees accrued by Noble prior
+// to the v8 Helium upgrade (November 2024) to the x/authority owner. The funds
+// are currently stuck as the x/distribution module was removed and replaced by
+// the x/authority module without a proper migration of funds.
+func ClaimDistributionFunds(ctx context.Context, logger log.Logger, addressCodec address.Codec, authorityKeeper *authoritykeeper.Keeper, bankKeeper bankkeeper.Keeper) error {
+	// NOTE: We hardcode the x/distribution module name to avoid an import.
+	address := authtypes.NewModuleAddress("distribution")
+	balance := bankKeeper.GetAllBalances(ctx, address)
+	if balance.IsZero() {
+		// We return early in the case that there are no claimable funds.
+		return nil
+	}
+
+	authority, err := authorityKeeper.Owner.Get(ctx)
+	if err != nil {
+		return errors.New("unable to get underlying authority address from state")
+	}
+	authorityBz, err := addressCodec.StringToBytes(authority)
+	if err != nil {
+		return errors.New("unable to decode underlying authority address")
+	}
+
+	err = bankKeeper.SendCoins(ctx, address, authorityBz, balance)
+	if err != nil {
+		return errors.New("unable to transfer stuck distribution funds")
+	}
+
+	logger.Info("claimed stuck distribution module funds", "amount", balance.String())
+
+	return nil
 }


### PR DESCRIPTION
This PR claims the ~$14k worth of transaction fees currently stuck in the `x/distribution` module account. They are stuck because the `x/distribution` module was replaced by the `x/authority` module in the v8 Helium upgrade without a proper migration of funds.

This logic has been tested against an in-place-fork of mainnet at Block #32628500!

<img width="1512" height="336" alt="Screenshot 2025-08-11 at 12 09 32" src="https://github.com/user-attachments/assets/70cfd833-4351-4b7b-b678-44d6a5d27381" />