### PR TITLE
feat: allow hyperlane synthetic tokens

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -121,6 +121,7 @@ modules:
       authority: authority # Utilize our custom x/authority module.
       enabled_tokens:
         - 1 # Enable Collateral tokens
+        - 2 # Enable Synthetic tokens
 
   # Monerium Modules
   - name: florin


### PR DESCRIPTION
This PR enables synthetic tokens in the Hyperlane Warp module. This allows tokens to flow from the Noble Applayer (for example, $NOBLE) to Noble Core.