### PR TITLE
chore: recover expired shido ibc light client

### DIFF
--- a/.changelog/unreleased/improvements/597-shido-client.md
+++ b/.changelog/unreleased/improvements/597-shido-client.md
@@ -1,0 +1,1 @@
+- Recover expired Shido IBC light client, `07-tendermint-106` → `07-tendermint-186` ([#597](https://github.com/noble-assets/noble/pull/597))

--- a/app.go
+++ b/app.go
@@ -478,6 +478,7 @@ func (app *App) RegisterUpgradeHandler() error {
 			app.AccountKeeper.AddressCodec(),
 			app.AuthorityKeeper,
 			app.BankKeeper,
+			app.IBCKeeper.ClientKeeper,
 			app.DollarKeeper,
 		),
 	)

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -27,7 +27,7 @@ func TestChainUpgrade(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	genesisVersion := "v10.1.0"
+	genesisVersion := "v10.1.1"
 
 	upgrades := []e2e.ChainUpgrade{
 		{

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -186,8 +186,8 @@ func modifyGenesisAll(nw *NobleWrapper, setupAllCircleRoles bool) func(cc ibc.Ch
 		}
 
 		// Modify the genesis file with the appropriate Dollar Vaults Season One and Two state.
-		// For v10.1.0, we opt to not set this state as these values were hardcoded in the app wiring!
-		if cc.Images[0].Version != "v10.1.0" {
+		// For v10.1, we opt to not set this state as these values were hardcoded in the app wiring!
+		if cc.Images[0].Version != "v10.1.1" {
 			updatedGenesis = append(updatedGenesis, cosmos.NewGenesisKV("app_state.dollar.vaults.season_one_ended", true))
 			updatedGenesis = append(updatedGenesis, cosmos.NewGenesisKV("app_state.dollar.vaults.season_two_yield_collector", nw.Authority.FormattedAddress()))
 		}

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -68,7 +68,7 @@ func CreateUpgradeHandler(
 		if sdkCtx.ChainID() == MainnetChainID {
 			err = clientKeeper.RecoverClient(sdkCtx, "07-tendermint-106", "07-tendermint-186")
 			if err != nil {
-				return vm, err
+				logger.Error("unable to recover shido_9008-1 light client", "err", err)
 			}
 		}
 

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	clientkeeper "github.com/cosmos/ibc-go/v8/modules/core/02-client/keeper"
 	authoritykeeper "github.com/noble-assets/authority/keeper"
 )
 
@@ -38,9 +39,12 @@ func CreateUpgradeHandler(
 	addressCodec address.Codec,
 	authorityKeeper *authoritykeeper.Keeper,
 	bankKeeper bankkeeper.Keeper,
+	clientKeeper clientkeeper.Keeper,
 	dollarKeeper *dollarkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+
 		vm, err := mm.RunMigrations(ctx, cfg, vm)
 		if err != nil {
 			return vm, err
@@ -54,6 +58,18 @@ func CreateUpgradeHandler(
 		err = UpdateVaultsState(ctx, addressCodec, authorityKeeper, dollarKeeper)
 		if err != nil {
 			return vm, err
+		}
+
+		// The IBC light client for the shido_9008-1 chain has expired on
+		// Noble's mainnet. In IBC-Go v8.7.0, the MsgRecoverClient message does
+		// not support the LegacyAminoJSON signing mode, preventing recovery
+		// via the Noble Maintenance Multisig. As a result, the client must be
+		// manually recovered as part of this software upgrade.
+		if sdkCtx.ChainID() == MainnetChainID {
+			err = clientKeeper.RecoverClient(sdkCtx, "07-tendermint-106", "07-tendermint-186")
+			if err != nil {
+				return vm, err
+			}
 		}
 
 		logger.Info(UpgradeASCII)


### PR DESCRIPTION
This PR adds upgrade logic to the v11 Flux line to recover the expired [Shido](https://shido.io/) IBC light client.

This has been tested locally against an in-place fork of mainnet :

<img width="1125" height="374" alt="Screenshot 2025-10-01 at 14 22 56" src="https://github.com/user-attachments/assets/c1e2c580-3c5f-441d-bcde-b1e4997c8edf" />
