### PR TITLE
chore: recover `evmos_9001-2` light client

### DIFF
--- a/.changelog/v11.3.0/improvements/628-recover-client.md
+++ b/.changelog/v11.3.0/improvements/628-recover-client.md
@@ -1,0 +1,1 @@
+- Recover expired IBC light client for `evmos_9001-2` ([#628](https://github.com/noble-assets/noble/pull/628))

--- a/.changelog/v11.3.0/summary.md
+++ b/.changelog/v11.3.0/summary.md
@@ -1,3 +1,3 @@
-*Feb 20, 2026*
+*Feb 23, 2026*
 
 This is a minor release to the v11 Flux line.

--- a/.changelog/v11.3.0/summary.md
+++ b/.changelog/v11.3.0/summary.md
@@ -1,0 +1,3 @@
+*Feb 20, 2026*
+
+This is a minor release to the v11 Flux line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v11.3.0
+
+*Feb 20, 2026*
+
+This is a minor release to the v11 Flux line.
+
+### IMPROVEMENTS
+
+- Recover expired IBC light client for `evmos_9001-2` ([#628](https://github.com/noble-assets/noble/pull/628))
+
 ## v11.2.0
 
 *Jan 23, 2026*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v11.3.0
 
-*Feb 20, 2026*
+*Feb 23, 2026*
 
 This is a minor release to the v11 Flux line.
 

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -27,12 +27,12 @@ func TestChainUpgrade(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	genesisVersion := "v11.1.0"
+	genesisVersion := "v11.2.0"
 
 	upgrades := []e2e.ChainUpgrade{
 		{
 			Image:       e2e.LocalImages[0],
-			UpgradeName: "v11.2.0",
+			UpgradeName: "v11.3.0",
 		},
 	}
 

--- a/upgrade/constants.go
+++ b/upgrade/constants.go
@@ -17,7 +17,7 @@
 package upgrade
 
 // UpgradeName is the name of this specific software upgrade used on-chain.
-const UpgradeName = "v11.2.0"
+const UpgradeName = "v11.3.0"
 
 // TestnetChainID is the Chain ID of the Noble testnet.
 const TestnetChainID = "grand-1"

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -45,20 +45,10 @@ func CreateUpgradeHandler(
 		// Maintenance Multisig. As a result, expired clients on mainnet must
 		// be manually recovered as part of a software upgrade.
 		if sdkCtx.ChainID() == MainnetChainID {
-			// Substitute the IBC light client for the haqq_11235-1 chain.
-			err = clientKeeper.RecoverClient(sdkCtx, "07-tendermint-58", "07-tendermint-194")
+			// Substitute the IBC light client for the evmos_9001-2 chain.
+			err = clientKeeper.RecoverClient(sdkCtx, "07-tendermint-12", "07-tendermint-208")
 			if err != nil {
-				logger.Error("failed to recover haqq_11235-1 client", "error", err)
-			}
-			// Substitute the IBC light client for the migaloo-1 chain.
-			err = clientKeeper.RecoverClient(sdkCtx, "07-tendermint-19", "07-tendermint-201")
-			if err != nil {
-				logger.Error("failed to recover migaloo-1 client", "error", err)
-			}
-			// Substitute the IBC light client for the omniflixhub-1 chain.
-			err = clientKeeper.RecoverClient(sdkCtx, "07-tendermint-68", "07-tendermint-198")
-			if err != nil {
-				logger.Error("failed to recover omniflixhub-1 client", "error", err)
+				logger.Error("failed to recover evmos_9001-2 client", "error", err)
 			}
 		}
 


### PR DESCRIPTION
Closes #627