### PR TITLE
chore: recover `coreum-mainnet-1` light client

### DIFF
--- a/.changelog/v11.5.0/improvements/647-recover-client.md
+++ b/.changelog/v11.5.0/improvements/647-recover-client.md
@@ -1,0 +1,1 @@
+- Recover expired IBC light client for `coreum-mainnet-1` ([#647](https://github.com/noble-assets/noble/pull/647))

--- a/.changelog/v11.5.0/summary.md
+++ b/.changelog/v11.5.0/summary.md
@@ -1,0 +1,3 @@
+*Jul 8, 2026*
+
+This is a minor release to the v11 Flux line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v11.5.0
+
+*Jul 8, 2026*
+
+This is a minor release to the v11 Flux line.
+
+### IMPROVEMENTS
+
+- Recover expired IBC light client for `coreum-mainnet-1` ([#647](https://github.com/noble-assets/noble/pull/647))
+
 ## v11.4.0
 
 *Apr 9, 2026*

--- a/app.go
+++ b/app.go
@@ -476,9 +476,7 @@ func (app *App) RegisterUpgradeHandler() error {
 			app.ModuleManager,
 			app.Configurator(),
 			app.Logger(),
-			app.AccountKeeper.AddressCodec(),
 			app.IBCKeeper.ClientKeeper,
-			app.DollarKeeper,
 		),
 	)
 

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -27,12 +27,12 @@ func TestChainUpgrade(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	genesisVersion := "v11.2.0"
+	genesisVersion := "v11.4.0"
 
 	upgrades := []e2e.ChainUpgrade{
 		{
 			Image:       e2e.LocalImages[0],
-			UpgradeName: "v11.4.0",
+			UpgradeName: "v11.5.0",
 		},
 	}
 

--- a/upgrade/constants.go
+++ b/upgrade/constants.go
@@ -17,7 +17,7 @@
 package upgrade
 
 // UpgradeName is the name of this specific software upgrade used on-chain.
-const UpgradeName = "v11.4.0"
+const UpgradeName = "v11.5.0"
 
 // TestnetChainID is the Chain ID of the Noble testnet.
 const TestnetChainID = "grand-1"

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -18,28 +18,19 @@ package upgrade
 
 import (
 	"context"
-	"fmt"
-	"sort"
 
-	"cosmossdk.io/core/address"
 	"cosmossdk.io/log"
-	"cosmossdk.io/math"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
-	dollarkeeper "dollar.noble.xyz/v2/keeper"
-	vaultstypes "dollar.noble.xyz/v2/types/vaults"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	clientkeeper "github.com/cosmos/ibc-go/v8/modules/core/02-client/keeper"
-	authoritytypes "github.com/noble-assets/authority/types"
 )
 
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	cfg module.Configurator,
 	logger log.Logger,
-	addressCdc address.Codec,
 	clientKeeper clientkeeper.Keeper,
-	dollarKeeper *dollarkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		vm, err := mm.RunMigrations(ctx, cfg, vm)
@@ -54,94 +45,13 @@ func CreateUpgradeHandler(
 		// Maintenance Multisig. As a result, expired clients on mainnet must
 		// be manually recovered as part of a software upgrade.
 		if sdkCtx.ChainID() == MainnetChainID {
-			// Substitute the IBC light client for the evmos_9001-2 chain.
-			err = clientKeeper.RecoverClient(sdkCtx, "07-tendermint-12", "07-tendermint-208")
+			// Substitute the IBC light client for the coreum-mainnet-1 chain.
+			err = clientKeeper.RecoverClient(sdkCtx, "07-tendermint-71", "07-tendermint-226")
 			if err != nil {
-				logger.Error("failed to recover evmos_9001-2 client", "error", err)
+				logger.Error("failed to recover coreum-mainnet-1 client", "error", err)
 			}
-			// Substitute the IBC light client for the haqq_11235-1 chain.
-			err = clientKeeper.RecoverClient(sdkCtx, "07-tendermint-58", "07-tendermint-194")
-			if err != nil {
-				logger.Error("failed to recover haqq_11235-1 client", "error", err)
-			}
-		}
-
-		vaultServer := dollarkeeper.NewVaultsMsgServer(dollarKeeper)
-
-		// Unlock all user positions from the Staked Vault.
-		if err = endVaultsSeasonTwo(ctx, logger, addressCdc, dollarKeeper, vaultServer); err != nil {
-			return vm, err
-		}
-
-		// Pause all Vaults permanently.
-		if _, err = vaultServer.SetPausedState(ctx, &vaultstypes.MsgSetPausedState{
-			Signer: authoritytypes.ModuleAddress.String(),
-			Paused: vaultstypes.ALL,
-		}); err != nil {
-			return vm, err
 		}
 
 		return vm, nil
 	}
-}
-
-// endVaultsSeasonTwo handles the logic to end Vaults Season Two, unlocking all
-// Staked vault user positions.
-func endVaultsSeasonTwo(
-	ctx context.Context,
-	logger log.Logger,
-	addressCdc address.Codec,
-	k *dollarkeeper.Keeper,
-	vaultServer vaultstypes.MsgServer,
-) error {
-	// Get all the vaults positions.
-	positions, err := k.GetVaultsPositions(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Create a mapping by address and the total positions amount.
-	stakedUsers := map[string]math.Int{}
-	var stakedUsersAddress []string
-
-	// Iterate through all the positions.
-	logger.Info("collecting vault positions")
-	for _, position := range positions {
-		switch position.Vault {
-		case vaultstypes.STAKED:
-			addr, err := addressCdc.BytesToString(position.Address)
-			if err != nil {
-				logger.Warn("invalid position address: " + err.Error())
-				continue
-			}
-
-			if _, exists := stakedUsers[addr]; !exists {
-				stakedUsers[addr] = position.Amount
-				stakedUsersAddress = append(stakedUsersAddress, addr)
-			} else {
-				stakedUsers[addr] = stakedUsers[addr].Add(position.Amount)
-			}
-		}
-	}
-
-	sort.Strings(stakedUsersAddress)
-
-	// Unlock all the Staked vault positions.
-	logger.Info(fmt.Sprintf("unlocking %d staked vault positions", len(stakedUsers)))
-	stakedUsersProcessed := 0
-	for _, stakedUserAddr := range stakedUsersAddress {
-		stakedUserTotalAmount := stakedUsers[stakedUserAddr]
-		if _, unlockErr := vaultServer.Unlock(ctx, &vaultstypes.MsgUnlock{
-			Signer: stakedUserAddr,
-			Vault:  vaultstypes.STAKED,
-			Amount: stakedUserTotalAmount,
-		}); unlockErr != nil {
-			logger.Error(fmt.Sprintf("failed to unlock staked vault position for %s: %v", stakedUserAddr, err))
-			continue
-		}
-		stakedUsersProcessed += 1
-	}
-	logger.Info(fmt.Sprintf("unlocked %d/%d staked vault positions successfully", stakedUsersProcessed, len(stakedUsers)))
-
-	return nil
 }


### PR DESCRIPTION
Tested against an in-place fork of mainnet at Block #54284500:

<img width="984" height="367" alt="Screenshot 2026-07-08 at 14 27 26" src="https://github.com/user-attachments/assets/17e15ba3-6f92-4326-8168-962eb03a01ea" />
<img width="815" height="120" alt="Screenshot 2026-07-08 at 14 28 13" src="https://github.com/user-attachments/assets/3358d4d8-26d3-4faf-91d9-8bc71537c59b" />